### PR TITLE
Add `yarn git-info` step to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y gpg curl git ma
 
 
 COPY . /app/
+RUN yarn git-info
 RUN yarn install
 RUN yarn build
 


### PR DESCRIPTION
### What

Add `yarn git-info` step to the Dockerfile

### Why

I noticed that the public images published in https://hub.docker.com/r/stellar/stellar-disbursement-platform-frontend have these fields empty. I believe this small change will fix that.