### PR TITLE
SDP-897: Remove Stellar logo from Page Header

### DIFF
--- a/src/components/PageHeader/index.tsx
+++ b/src/components/PageHeader/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import { Button, Icon, Logo, ThemeSwitch } from "@stellar/design-system";
+import { Button, Icon, ThemeSwitch } from "@stellar/design-system";
 import { PROJECT_NAME, Routes } from "constants/settings";
 import { DropdownMenu } from "components/DropdownMenu";
 import { formatDateTimeWithGmt } from "helpers/formatIntlDateTime";
@@ -22,7 +22,7 @@ export const PageHeader = ({
     <div className={`PageHeader ${username ? "PageHeader--internal" : ""}`}>
       <div className="PageHeader__inset">
         <div className="PageHeader__logo">
-          {username ? (
+          {username && (
             <div className="CompanyBrand">
               <div
                 className="CompanyBrand__logo"
@@ -32,8 +32,6 @@ export const PageHeader = ({
                 {companyName || "Company Name"}
               </div>
             </div>
-          ) : (
-            <Logo.Stellar />
           )}
         </div>
       </div>

--- a/src/generated/gitInfo.ts
+++ b/src/generated/gitInfo.ts
@@ -1,1 +1,1 @@
-export default { commitHash: "d13cf63", version: "1.0.0-rc2-10-gd13cf63" };
+export default { commitHash: "4aaf371", version: "1.0.0-rc2-21-g4aaf371" };

--- a/src/generated/gitInfo.ts
+++ b/src/generated/gitInfo.ts
@@ -1,1 +1,1 @@
-export default { commitHash: "4aaf371", version: "1.0.0-rc2-21-g4aaf371" };
+export default { commitHash: "d13cf63", version: "1.0.0-rc2-10-gd13cf63" };


### PR DESCRIPTION
It was decided to not use the Stellar logo in the product, since this will be hosted by others and if we were to use the Stellar logo, it could seem like we’re co-responsible for their use case, which could raise a legal problem for SDF.