### PR TITLE
SDP-895: Include trustline asset issuer

### DIFF
--- a/src/components/WalletTrustlines/index.tsx
+++ b/src/components/WalletTrustlines/index.tsx
@@ -239,7 +239,9 @@ export const WalletTrustlines = ({
             >
               <div className="WalletTrustlines__asset__info">
                 <div>{ASSET_NAME?.[a.code] || ""}</div>
-                <span>{a.code}</span>
+                <span>
+                  {a.code}:{a.issuer}
+                </span>
               </div>
 
               {!a.isNative && a.id ? (

--- a/src/components/WalletTrustlines/index.tsx
+++ b/src/components/WalletTrustlines/index.tsx
@@ -238,7 +238,7 @@ export const WalletTrustlines = ({
               key={`${a.code}-${a.issuer}`}
             >
               <div className="WalletTrustlines__asset__info">
-                <div>{ASSET_NAME?.[a.code] || ""}</div>
+                {ASSET_NAME?.[a.code] && <div>{ASSET_NAME?.[a.code]}</div>}
                 <span>
                   {a.code}:{a.issuer}
                 </span>

--- a/src/components/WalletTrustlines/styles.scss
+++ b/src/components/WalletTrustlines/styles.scss
@@ -3,7 +3,6 @@
 .WalletTrustlines {
   &__asset {
     display: flex;
-    align-items: center;
     justify-content: space-between;
     gap: pxToRem(16px);
     border: 1px solid var(--color-gray-30);

--- a/src/components/WalletTrustlines/styles.scss
+++ b/src/components/WalletTrustlines/styles.scss
@@ -13,6 +13,7 @@
 
     &__info {
       display: flex;
+      flex-direction: column;
       gap: pxToRem(8px);
       align-items: center;
       font-size: pxToRem(14px);
@@ -22,6 +23,7 @@
 
       span {
         color: var(--color-gray-60);
+        font-size: pxToRem(12px);
       }
     }
   }

--- a/src/components/WalletTrustlines/styles.scss
+++ b/src/components/WalletTrustlines/styles.scss
@@ -15,7 +15,6 @@
       display: flex;
       flex-direction: column;
       gap: pxToRem(8px);
-      align-items: center;
       font-size: pxToRem(14px);
       line-height: pxToRem(22px);
       font-weight: var(--font-weight-regular);


### PR DESCRIPTION
The screen that lists the trustlines doesn't show the issuer of an asset, just its code.
You can't tell if the asset is correct just by that.
It’s a basic concept of the Stellar network that an asset consists of the pair Code:Issuer. 

<img width="653" alt="Screenshot 2023-10-09 at 15 10 04" src="https://github.com/stellar/stellar-disbursement-platform-frontend/assets/11914514/470ccfcb-4b27-4221-b540-a89764c60aee">
