### PR TITLE
Remove generated/gitInfo.ts file from repo

### DIFF
--- a/src/generated/gitInfo.ts
+++ b/src/generated/gitInfo.ts
@@ -1,1 +1,0 @@
-export default { commitHash: "d13cf63", version: "1.0.0-rc2-10-gd13cf63" };


### PR DESCRIPTION
This file is generated during the build process, so we don't need to have it in the repo. It's causing a lot of unnecessary merge conflicts because it changes on every commit.