### PR TITLE
SDP-830: New Disbursement - Filtering of assets based on wallet selection

### DIFF
--- a/src/api/getAssetsByWallet.ts
+++ b/src/api/getAssetsByWallet.ts
@@ -1,0 +1,18 @@
+import { handleApiResponse } from "api/handleApiResponse";
+import { API_URL } from "constants/settings";
+import { ApiAsset } from "types";
+
+export const getAssetsByWallet = async (
+  token: string,
+  wallet_id: string,
+): Promise<ApiAsset[]> => {
+  const response = await fetch(`${API_URL}/assets?wallet=${wallet_id}`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  return handleApiResponse(response);
+};

--- a/src/components/DisbursementDetails/index.tsx
+++ b/src/components/DisbursementDetails/index.tsx
@@ -10,7 +10,7 @@ import { useDispatch } from "react-redux";
 
 import { AppDispatch } from "store";
 import { getCountriesAction } from "store/ducks/countries";
-import { getAssetsAction } from "store/ducks/assets";
+import { getAssetsByWalletAction } from "store/ducks/assets";
 import { getWalletsAction } from "store/ducks/wallets";
 
 import { InfoTooltip } from "components/InfoTooltip";
@@ -82,19 +82,25 @@ export const DisbursementDetails: React.FC<DisbursementDetailsProps> = ({
       dispatch(getCountriesAction());
     }
 
-    if (!assets.status) {
-      dispatch(getAssetsAction());
-    }
-
     if (!wallets.status) {
       dispatch(getWalletsAction());
     }
-  }, [assets.status, countries.status, wallets.status, dispatch]);
+
+    if (!assets.status) {
+      dispatch(getAssetsByWalletAction({ wallet_id: details.wallet.id }));
+    }
+  }, [
+    dispatch,
+    assets.status,
+    countries.status,
+    wallets.status,
+    details.wallet.id,
+  ]);
 
   const apiErrors = [
-    assets.errorString,
     countries.errorString,
     wallets.errorString,
+    assets.errorString,
   ];
 
   const sanitizedApiErrors = apiErrors.filter((e) => Boolean(e));
@@ -106,10 +112,10 @@ export const DisbursementDetails: React.FC<DisbursementDetailsProps> = ({
       missingFields.push(FieldId.NAME);
     } else if (!inputs.country.code) {
       missingFields.push(FieldId.COUNTRY_CODE);
-    } else if (!inputs.asset.code) {
-      missingFields.push(FieldId.ASSET_CODE);
     } else if (!inputs.wallet.id) {
       missingFields.push(FieldId.WALLET_ID);
+    } else if (!inputs.asset.code) {
+      missingFields.push(FieldId.ASSET_CODE);
     }
 
     const isValid = missingFields.length === 0;
@@ -153,18 +159,6 @@ export const DisbursementDetails: React.FC<DisbursementDetailsProps> = ({
         });
 
         break;
-      case FieldId.ASSET_CODE:
-        // eslint-disable-next-line no-case-declarations
-        const asset = assets.items.find((a: ApiAsset) => a.id === value);
-
-        updateState({
-          asset: {
-            id: asset?.id || "",
-            code: asset?.code || "",
-          },
-        });
-
-        break;
       case FieldId.WALLET_ID:
         // eslint-disable-next-line no-case-declarations
         const wallet = wallets.items.find((w: ApiWallet) => w.id === value);
@@ -173,6 +167,19 @@ export const DisbursementDetails: React.FC<DisbursementDetailsProps> = ({
           wallet: {
             id: wallet?.id || "",
             name: wallet?.name || "",
+          },
+        });
+        dispatch(getAssetsByWalletAction({ wallet_id: details.wallet.id }));
+
+        break;
+      case FieldId.ASSET_CODE:
+        // eslint-disable-next-line no-case-declarations
+        const asset = assets.items.find((a: ApiAsset) => a.id === value);
+
+        updateState({
+          asset: {
+            id: asset?.id || "",
+            code: asset?.code || "",
           },
         });
 
@@ -203,16 +210,16 @@ export const DisbursementDetails: React.FC<DisbursementDetailsProps> = ({
           </div>
 
           <div>
-            <label className="Label Label--sm">Asset</label>
+            <label className="Label Label--sm">Wallet provider</label>
             <div className="DisbursementDetailsFields__value">
-              {details.asset.code}
+              {details.wallet.name}
             </div>
           </div>
 
           <div>
-            <label className="Label Label--sm">Wallet provider</label>
+            <label className="Label Label--sm">Asset</label>
             <div className="DisbursementDetailsFields__value">
-              {details.wallet.name}
+              {details.asset.code}
             </div>
           </div>
 
@@ -255,22 +262,6 @@ export const DisbursementDetails: React.FC<DisbursementDetailsProps> = ({
         </Select>
 
         <Select
-          id={FieldId.ASSET_CODE}
-          label="Asset"
-          fieldSize="sm"
-          onChange={updateDraftDetails}
-          value={details.asset.id}
-          disabled={assets.status === "PENDING"}
-        >
-          {renderDropdownDefault(assets.status === "PENDING")}
-          {assets.items.map((asset: ApiAsset) => (
-            <option key={asset.id} value={asset.id}>
-              {asset.code}
-            </option>
-          ))}
-        </Select>
-
-        <Select
           id={FieldId.WALLET_ID}
           label="Wallet provider"
           fieldSize="sm"
@@ -282,6 +273,22 @@ export const DisbursementDetails: React.FC<DisbursementDetailsProps> = ({
           {wallets.items.map((wallet: ApiWallet) => (
             <option key={wallet.id} value={wallet.id}>
               {wallet.name}
+            </option>
+          ))}
+        </Select>
+
+        <Select
+          id={FieldId.ASSET_CODE}
+          label="Asset"
+          fieldSize="sm"
+          onChange={updateDraftDetails}
+          value={details.asset.id}
+          disabled={assets.status === "PENDING" || !details.wallet.id}
+        >
+          {renderDropdownDefault(assets.status === "PENDING")}
+          {assets.items.map((asset: ApiAsset) => (
+            <option key={asset.id} value={asset.id}>
+              {asset.code}
             </option>
           ))}
         </Select>

--- a/src/store/ducks/assets.ts
+++ b/src/store/ducks/assets.ts
@@ -1,6 +1,7 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import { RootState } from "store";
 import { getAssets } from "api/getAssets";
+import { getAssetsByWallet } from "api/getAssetsByWallet";
 import { handleApiErrorString } from "api/handleApiErrorString";
 import { endSessionIfTokenInvalid } from "helpers/endSessionIfTokenInvalid";
 import { ApiAsset, ApiError, AssetsInitialState, RejectMessage } from "types";
@@ -16,6 +17,30 @@ export const getAssetsAction = createAsyncThunk<
 
     try {
       const assets = await getAssets(token);
+      // Don't show soft-deleted assets
+      return assets.filter((a) => !a.deleted_at);
+    } catch (error: unknown) {
+      const errorString = handleApiErrorString(error as ApiError);
+      endSessionIfTokenInvalid(errorString, dispatch);
+
+      return rejectWithValue({
+        errorString: `Error fetching assets: ${errorString}`,
+      });
+    }
+  },
+);
+
+export const getAssetsByWalletAction = createAsyncThunk<
+  ApiAsset[],
+  { wallet_id: string },
+  { rejectValue: RejectMessage; state: RootState }
+>(
+  "assets/getAssetsByWalletAction",
+  async ({ wallet_id }, { rejectWithValue, getState, dispatch }) => {
+    const { token } = getState().userAccount;
+
+    try {
+      const assets = await getAssetsByWallet(token, wallet_id);
       // Don't show soft-deleted assets
       return assets.filter((a) => !a.deleted_at);
     } catch (error: unknown) {
@@ -49,6 +74,19 @@ const assetsSlice = createSlice({
       state.errorString = undefined;
     });
     builder.addCase(getAssetsAction.rejected, (state, action) => {
+      state.status = "ERROR";
+      state.errorString = action.payload?.errorString;
+    });
+
+    builder.addCase(getAssetsByWalletAction.pending, (state = initialState) => {
+      state.status = "PENDING";
+    });
+    builder.addCase(getAssetsByWalletAction.fulfilled, (state, action) => {
+      state.items = action.payload;
+      state.status = "SUCCESS";
+      state.errorString = undefined;
+    });
+    builder.addCase(getAssetsByWalletAction.rejected, (state, action) => {
       state.status = "ERROR";
       state.errorString = action.payload?.errorString;
     });


### PR DESCRIPTION
When the `New Disbursement` page is first accessed, the `assets` dropdown is disabled
When a user selects a Wallet, `GET /assets?wallet=wallet_id` is called to fetch only assets associated with that wallet. Whenever a user changes the wallet selection, the list of assets is reloaded. 