### PR TITLE
[SDP-1024] Display external payment ID in Payment Details page

### DIFF
--- a/src/helpers/formatPaymentDetails.ts
+++ b/src/helpers/formatPaymentDetails.ts
@@ -12,6 +12,7 @@ export const formatPaymentDetails = (payment: ApiPayment): PaymentDetails => {
     senderAddress: payment.stellar_address,
     totalAmount: payment.amount,
     assetCode: payment.asset.code,
+    externalPaymentId: payment?.external_payment_id,
     status: payment.status,
     statusHistory: payment?.status_history
       .sort(

--- a/src/pages/PaymentDetails.tsx
+++ b/src/pages/PaymentDetails.tsx
@@ -243,6 +243,13 @@ export const PaymentDetails = () => {
                       )}
                     </div>
                   </div>
+
+                  <div className="PaymentDetails__info">
+                    <label className="Label">External Payment ID</label>
+                    <div>
+                      {shortenString(formattedPayment.externalPaymentId, 15) || "-"}
+                    </div>
+                  </div>
                 </div>
               </Card>
             </div>

--- a/src/pages/PaymentDetails.tsx
+++ b/src/pages/PaymentDetails.tsx
@@ -247,7 +247,11 @@ export const PaymentDetails = () => {
                   <div className="PaymentDetails__info">
                     <label className="Label">External Payment ID</label>
                     <div>
-                      {shortenString(formattedPayment.externalPaymentId, 15) || "-"}
+                      {formattedPayment.externalPaymentId ? 
+                        (formattedPayment.externalPaymentId.length > 20 ?
+                          shortenString(formattedPayment.externalPaymentId, 10) : formattedPayment.externalPaymentId) 
+                        : "-"
+                      }
                     </div>
                   </div>
                 </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -339,6 +339,7 @@ export type PaymentDetails = {
   assetCode: string;
   status: string;
   statusHistory: PaymentDetailsStatusHistoryItem[];
+  externalPaymentId: string;
 };
 
 // =============================================================================
@@ -616,6 +617,7 @@ export type ApiPayment = {
   receiver_wallet: ApiPaymentReceiverWallet;
   created_at: string;
   updated_at: string;
+  external_payment_id: string;
 };
 
 export type ApiPayments = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -339,7 +339,7 @@ export type PaymentDetails = {
   assetCode: string;
   status: string;
   statusHistory: PaymentDetailsStatusHistoryItem[];
-  externalPaymentId: string;
+  externalPaymentId?: string;
 };
 
 // =============================================================================
@@ -617,7 +617,7 @@ export type ApiPayment = {
   receiver_wallet: ApiPaymentReceiverWallet;
   created_at: string;
   updated_at: string;
-  external_payment_id: string;
+  external_payment_id?: string;
 };
 
 export type ApiPayments = {


### PR DESCRIPTION
Displays an "External Payment ID" on the payments page if one is valid. The id can be variable length depending on the org so we will displayed a shortened string for id's that are longer than 20 characters.

id longer than 20 chars
<img width="1179" alt="Screenshot 2024-01-02 at 3 30 03 PM" src="https://github.com/stellar/stellar-disbursement-platform-frontend/assets/20179122/c2b52f90-2c06-4b71-bec7-5a77c5113e58">

id less than 20 chars
<img width="1180" alt="Screenshot 2024-01-02 at 3 30 15 PM" src="https://github.com/stellar/stellar-disbursement-platform-frontend/assets/20179122/9316d56c-0fe2-4417-8c36-1d29a339370e">

no id
<img width="1162" alt="Screenshot 2024-01-02 at 3 31 51 PM" src="https://github.com/stellar/stellar-disbursement-platform-frontend/assets/20179122/bad46956-8f25-486f-9ecc-a36b10e4d2ff">
