### PR TITLE
[Hot-fix] Retry payment button was not showing up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,41 +8,69 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 > Place unreleased changes here.
 
+## [1.1.1](https://github.com/stellar/stellar-disbursement-platform-backend/compare/1.1.0...1.1.1)
+
+### Fixed
+
+- Retry payment button was not showing up on failed payments
+  [#72](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/72).
+
 ## [1.1.0](https://github.com/stellar/stellar-disbursement-platform-backend/compare/1.0.1...1.1.0)
 
 ### Added
-- Add dropdown for choosing verification type when creating new disbursements [#53](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/53)
-- Display external payment ID on payments details page [#59](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/59)
-- Add a cancel button to payments details page [#60](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/60)
-- Add env variable injection to dashboard [#62](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/62)
-- Add SMS preview & editing before sending a new disbursement [#66](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/66)
-- Display `Created By` and `Started By` on disbursement details page [#68](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/68)
 
+- Add dropdown for choosing verification type when creating new disbursements
+  [#53](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/53)
+- Display external payment ID on payments details page
+  [#59](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/59)
+- Add a cancel button to payments details page
+  [#60](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/60)
+- Add env variable injection to dashboard
+  [#62](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/62)
+- Add SMS preview & editing before sending a new disbursement
+  [#66](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/66)
+- Display `Created By` and `Started By` on disbursement details page
+  [#68](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/68)
 
 ### Changed
 
 - State Refactors
-  - receiver payments, wallet balance, wallet history [#34](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/34)
-  - users [#36](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/36)
-  - wallet providers [#37](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/37)
-  - countries [#42](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/42)
-- Automatic cancellation of payments in `READY` status after a certain time period [#38](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/38)
-
+  - receiver payments, wallet balance, wallet history
+    [#34](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/34)
+  - users
+    [#36](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/36)
+  - wallet providers
+    [#37](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/37)
+  - countries
+    [#42](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/42)
+- Automatic cancellation of payments in `READY` status after a certain time
+  period
+  [#38](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/38)
 
 ### Chores
-- Optimize refresh token for dispatch actions [#39](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/39)
-- Analytics cards: adjust layout [#47](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/47)
-- Updated favicons and README [#64](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/64)
-- Business user role should receive permission to view details for individual payments, details, and receivers [#63](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/63)
-- Standardize errors with extras [#61](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/61)
-- Update SDS package [#58](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/58)
-- Show error details upon sign-in [#57](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/57)
 
+- Optimize refresh token for dispatch actions
+  [#39](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/39)
+- Analytics cards: adjust layout
+  [#47](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/47)
+- Updated favicons and README
+  [#64](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/64)
+- Business user role should receive permission to view details for individual
+  payments, details, and receivers
+  [#63](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/63)
+- Standardize errors with extras
+  [#61](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/61)
+- Update SDS package
+  [#58](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/58)
+- Show error details upon sign-in
+  [#57](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/57)
 
 ### Fixed
-- Fix input entry for Payments cancellation and SMS retry [#43](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/43)
-- Fix table overflow crop [#55](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/55)
 
+- Fix input entry for Payments cancellation and SMS retry
+  [#43](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/43)
+- Fix table overflow crop
+  [#55](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/55)
 
 ## [1.0.0](https://github.com/stellar/stellar-disbursement-platform-backend/compare/1.0.0-rc2...1.0.0)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellar-disbursement-platform-frontend",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "Apache-2.0",
   "engines": {
     "node": ">=18.x"

--- a/src/components/RetryFailedPayment.tsx
+++ b/src/components/RetryFailedPayment.tsx
@@ -2,18 +2,21 @@ import { useEffect } from "react";
 import { Banner, Icon, Link, Loader } from "@stellar/design-system";
 import { useQueryClient } from "@tanstack/react-query";
 import { usePaymentsRetry } from "apiQueries/usePaymentsRetry";
-import { PaymentDetailsStatusHistoryItem } from "types";
+import { PaymentStatus } from "types";
 
 interface RetryFailedPaymentProps {
   paymentId: string;
-  paymentStatus: PaymentDetailsStatusHistoryItem[];
+  paymentStatus: PaymentStatus;
 }
 
 export const RetryFailedPayment = ({
   paymentId,
   paymentStatus,
 }: RetryFailedPaymentProps) => {
-  const isFailed = paymentStatus.slice(-1)[0]?.status === "FAILED";
+  console.log("paymentStatus", paymentStatus);
+  const isFailed = paymentStatus === "FAILED";
+
+  console.log("isFailed", isFailed);
 
   const { isFetching, data, isError, isSuccess, error, refetch } =
     usePaymentsRetry([paymentId]);

--- a/src/components/RetryFailedPayment.tsx
+++ b/src/components/RetryFailedPayment.tsx
@@ -16,8 +16,6 @@ export const RetryFailedPayment = ({
   console.log("paymentStatus", paymentStatus);
   const isFailed = paymentStatus === "FAILED";
 
-  console.log("isFailed", isFailed);
-
   const { isFetching, data, isError, isSuccess, error, refetch } =
     usePaymentsRetry([paymentId]);
   const queryClient = useQueryClient();

--- a/src/pages/PaymentDetails.tsx
+++ b/src/pages/PaymentDetails.tsx
@@ -151,7 +151,7 @@ export const PaymentDetails = () => {
           <div className="DetailsSection">
             <RetryFailedPayment
               paymentId={formattedPayment.id}
-              paymentStatus={formattedPayment.statusHistory}
+              paymentStatus={formattedPayment.status}
             />
 
             <SectionHeader>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -317,7 +317,7 @@ export type PaymentDetails = {
   senderAddress?: string;
   totalAmount: string;
   assetCode: string;
-  status: string;
+  status: PaymentStatus;
   statusHistory: PaymentDetailsStatusHistoryItem[];
   externalPaymentId?: string;
 };


### PR DESCRIPTION
### What

The retry payment button was not showing up after #15.

The code was relying on the order of the entries in the status_history array. Status history is metadata, so it's not very reliable and we should rely on the status instead.

### How was it tested?

1. Pointed my FE to the dev instance (https://stellar-disbursement-platform-backend-dev.stellar.org)
2. Created a payment to my phone number
3. Registered a wallet using the demo wallet, but without creating the account
4. The payment failed with op_no_destination
5. I created the account and retried it
6. The payment failed with op_no_trust
7. I created the trustline and retried it
8. It succeeded 🎉

The payment used for this test is at https://stellar-disbursement-platform-frontend-dev.stellar.org/payments/b27db2ed-dd87-4127-b165-98f98c70144b