### PR TITLE
[SDP-899] feat: patch receivers' verification info

### DIFF
--- a/src/apiQueries/useUpdateReceiverDetails.ts
+++ b/src/apiQueries/useUpdateReceiverDetails.ts
@@ -4,12 +4,23 @@ import { fetchApi } from "helpers/fetchApi";
 import { sanitizeObject } from "helpers/sanitizeObject";
 import { AppError } from "types";
 
+interface ReceiverDetailsUpdate {
+  email: string;
+  externalId: string;
+  dataOfBirth: string;
+  pin: string;
+  nationalId: string;
+}
+
 export const useUpdateReceiverDetails = (receiverId: string | undefined) => {
   const mutation = useMutation({
-    mutationFn: (fields: { email: string; externalId: string }) => {
+    mutationFn: (fields: ReceiverDetailsUpdate) => {
       const fieldsToSubmit = sanitizeObject({
         email: fields.email,
         external_id: fields.externalId,
+        date_of_birth: fields.dataOfBirth,
+        pin: fields.pin,
+        national_id: fields.nationalId,
       });
 
       if (Object.keys(fieldsToSubmit).length === 0) {

--- a/src/helpers/formatReceiver.ts
+++ b/src/helpers/formatReceiver.ts
@@ -30,7 +30,8 @@ export const formatReceiver = (receiver: ApiReceiver): ReceiverDetails => ({
     withdrawnAmount: "",
   })),
   verifications: receiver.verifications.map((v) => ({
-    verificationField: v.VerificationField,
-    value: v.HashedValue,
+    verificationField: v.verification_field,
+    value: v.hashed_value,
+    confirmedAt: v.confirmed_at,
   })),
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -364,6 +364,7 @@ export type ReceiverWallet = {
 export type ReceiverVerification = {
   verificationField: string;
   value: string;
+  confirmedAt?: string;
 };
 
 export type ReceiverWalletBalance = {
@@ -407,6 +408,9 @@ export type ReceiverDetails = {
 export type ReceiverEditFields = {
   email: string;
   externalId: string;
+  dateOfBirth: string;
+  pin: string;
+  nationalId: string;
 };
 
 // =============================================================================
@@ -715,8 +719,9 @@ export type ApiReceiverWallet = {
 };
 
 export type ApiReceiverVerification = {
-  VerificationField: string;
-  HashedValue: string;
+  verification_field: string;
+  hashed_value: string;
+  confirmed_at: string;
 };
 
 export type ApiReceiver = {


### PR DESCRIPTION
Now users can add/update the receivers' verification info. Only **NOT** confirmed verification can be updated.