### PR TITLE
SDP-1095 - [FE] getting 400 when calling GET `/organization/logo`

### DIFF
--- a/src/api/getOrgLogo.ts
+++ b/src/api/getOrgLogo.ts
@@ -1,7 +1,15 @@
 import { API_URL } from "constants/envVariables";
+import { getSdpTenantName } from "helpers/getSdpTenantName";
 
-export async function getOrgLogo(): Promise<string> {
-  const response = await fetch(`${API_URL}/organization/logo`);
+export async function getOrgLogo(token: string): Promise<string> {
+  const response = await fetch(`${API_URL}/organization/logo`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+      "SDP-Tenant-Name": getSdpTenantName(),
+    },
+  });
 
   const responseBlob = await response.blob();
   return URL.createObjectURL(responseBlob);

--- a/src/store/ducks/organization.ts
+++ b/src/store/ducks/organization.ts
@@ -79,19 +79,23 @@ export const getOrgLogoAction = createAsyncThunk<
   string,
   undefined,
   { rejectValue: RejectMessage; state: RootState }
->("organization/getOrgLogoAction", async (_, { rejectWithValue, dispatch }) => {
-  try {
-    return await getOrgLogo();
-  } catch (error: unknown) {
-    const apiError = normalizeApiError(error as ApiError);
-    const errorString = apiError.message;
-    endSessionIfTokenInvalid(errorString, dispatch);
+>(
+  "organization/getOrgLogoAction",
+  async (_, { rejectWithValue, getState, dispatch }) => {
+    const { token } = getState().userAccount;
+    try {
+      return await getOrgLogo(token);
+    } catch (error: unknown) {
+      const apiError = normalizeApiError(error as ApiError);
+      const errorString = apiError.message;
+      endSessionIfTokenInvalid(errorString, dispatch);
 
-    return rejectWithValue({
-      errorString: `Error fetching organization logo: ${errorString}`,
-    });
-  }
-});
+      return rejectWithValue({
+        errorString: `Error fetching organization logo: ${errorString}`,
+      });
+    }
+  },
+);
 
 export const getStellarAccountAction = createAsyncThunk<
   StellarAccountInfo,


### PR DESCRIPTION
Endpoint `GET /organization/logo` fails for multi-tenancy because the endpoint isn't authenticated and is not associated with a tenant. 

Adding authentication to `GET /organization/logo` solves this issue. 