### PR TITLE
[SDP-1121]: Improve frontend message when the distribution account doesn't exist

### DIFF
--- a/src/api/getStellarAccountInfo.ts
+++ b/src/api/getStellarAccountInfo.ts
@@ -1,5 +1,4 @@
 import { HORIZON_URL } from "constants/envVariables";
-import { shortenAccountKey } from "helpers/shortenAccountKey";
 import { ApiStellarAccount } from "types";
 
 export const getStellarAccountInfo = async (
@@ -10,7 +9,7 @@ export const getStellarAccountInfo = async (
   });
 
   if (response.status === 404) {
-    throw `${shortenAccountKey(stellarAddress)} address was not found.`;
+    throw `${stellarAddress} address was not found.`;
   }
 
   return await response.json();


### PR DESCRIPTION
The message is not helpful and you cannot read the whole public key, so it’s impossible to move on from here, unless you have access to the values from the DB. 
That happens in the “Distribution Account” screen.

Error message fixed to show entire public key.