### PR TITLE
SDP-1044 - prevent pre-release from pushing latest image

### DIFF
--- a/.github/workflows/docker_image_public_release.yml
+++ b/.github/workflows/docker_image_public_release.yml
@@ -43,7 +43,9 @@ jobs:
           push: true
           build-args: |
             GIT_COMMIT=${{ github.event.release.tag_name }}
-          tags: stellar/stellar-disbursement-platform-frontend:${{github.event.release.tag_name}},stellar/stellar-disbursement-platform-frontend:latest
+          tags: | 
+            stellar/stellar-disbursement-platform-frontend:${{github.event.release.tag_name}}
+            ${{ if eq(github.event.release.prerelease, 'false') }}stellar/stellar-disbursement-platform-frontend:latest${{ endif }}
           file: Dockerfile
 
   build_and_push_docker_image_on_dev_push:


### PR DESCRIPTION
We don't want to push a pre-release to `latest` docker tag