### PR TITLE
[SDP-1138]: Add seconds to payment history in Payment Details

### DIFF
--- a/src/helpers/formatIntlDateTime.ts
+++ b/src/helpers/formatIntlDateTime.ts
@@ -25,3 +25,17 @@ export const formatDateTime = (dateTime?: string) => {
 
   return dateTimeFormatter.format(date);
 };
+
+export const formatDateTimeWithSeconds = (dateTime?: string) => {
+  const date = dateTime ? new Date(dateTime) : new Date();
+  const dateTimeFormatter = new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+
+  return dateTimeFormatter.format(date);
+};

--- a/src/pages/PaymentDetails.tsx
+++ b/src/pages/PaymentDetails.tsx
@@ -182,7 +182,9 @@ export const PaymentDetails = () => {
                 <div className="PaymentDetails__wrapper">
                   <div className="PaymentDetails__info">
                     <label className="Label">Created at</label>
-                    <div>{formatDateTime(formattedPayment.createdAt)}</div>
+                    <div>
+                      {formatDateTimeWithSeconds(formattedPayment.createdAt)}
+                    </div>
                   </div>
 
                   <div className="PaymentDetails__info">

--- a/src/pages/PaymentDetails.tsx
+++ b/src/pages/PaymentDetails.tsx
@@ -20,7 +20,10 @@ import {
   CANCELED_PAYMENT_STATUS,
   READY_PAYMENT_STATUS,
 } from "constants/settings";
-import { formatDateTime } from "helpers/formatIntlDateTime";
+import {
+  formatDateTime,
+  formatDateTimeWithSeconds,
+} from "helpers/formatIntlDateTime";
 import { shortenString } from "helpers/shortenString";
 import { formatPaymentDetails } from "helpers/formatPaymentDetails";
 
@@ -297,7 +300,7 @@ export const PaymentDetails = () => {
                       </Table.BodyCell>
                       <Table.BodyCell textAlign="right">
                         <span className="Table-v2__cell--secondary">
-                          {formatDateTime(h.updatedAt)}
+                          {formatDateTimeWithSeconds(h.updatedAt)}
                         </span>
                       </Table.BodyCell>
                     </Table.BodyRow>


### PR DESCRIPTION
Payments are usually processed within one minute, which means the timestamps are not very meaningful. We should add seconds so a user can actually see the history and how the payment is processed on Stellar. ex: Mar 7, 2024, 12:57:06 PM

![image](https://github.com/stellar/stellar-disbursement-platform-frontend/assets/11914514/b15a0df8-256f-4c01-8863-113bc8d38bce)