### PR TITLE
[SDP-1206] Make sure to only export the envs needed

### DIFF
--- a/src/constants/envVariables.ts
+++ b/src/constants/envVariables.ts
@@ -6,11 +6,12 @@ export type OidcUsername = keyof Pick<
 >;
 
 declare global {
+  // ATTENTION: when adding a new environment variable, make sure to add it to the `generateEnvConfig` method below and
+  // `new DefinePlugin({"process.env": ...})` in the webpack config ad well.
   interface Window {
     _env_: {
       API_URL: string;
       STELLAR_EXPERT_URL: string;
-      USDC_ASSET_ISSUER: string;
       HORIZON_URL: string;
       RECAPTCHA_SITE_KEY: string;
 

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -141,7 +141,37 @@ module.exports = {
       process: "process/browser",
     }),
     new DefinePlugin({
-      "process.env": JSON.stringify(process.env),
+      "process.env": {
+        REACT_APP_DISABLE_WINDOW_ENV: JSON.stringify(
+          process.env.REACT_APP_DISABLE_WINDOW_ENV || "",
+        ),
+        REACT_APP_API_URL: JSON.stringify(process.env.REACT_APP_API_URL || ""),
+        REACT_APP_STELLAR_EXPERT_URL: JSON.stringify(
+          process.env.REACT_APP_STELLAR_EXPERT_URL || "",
+        ),
+        REACT_APP_HORIZON_URL: JSON.stringify(
+          process.env.REACT_APP_HORIZON_URL || "",
+        ),
+        REACT_APP_RECAPTCHA_SITE_KEY: JSON.stringify(
+          process.env.REACT_APP_RECAPTCHA_SITE_KEY || "",
+        ),
+        REACT_APP_USE_SSO: JSON.stringify(process.env.REACT_APP_USE_SSO || ""),
+        REACT_APP_OIDC_AUTHORITY: JSON.stringify(
+          process.env.REACT_APP_OIDC_AUTHORITY || "",
+        ),
+        REACT_APP_OIDC_CLIENT_ID: JSON.stringify(
+          process.env.REACT_APP_OIDC_CLIENT_ID || "",
+        ),
+        REACT_APP_OIDC_REDIRECT_URI: JSON.stringify(
+          process.env.REACT_APP_OIDC_REDIRECT_URI || "",
+        ),
+        REACT_APP_OIDC_SCOPE: JSON.stringify(
+          process.env.REACT_APP_OIDC_SCOPE || "",
+        ),
+        REACT_APP_OIDC_USERNAME_MAPPING: JSON.stringify(
+          process.env.REACT_APP_OIDC_USERNAME_MAPPING || "",
+        ),
+      },
     }),
     new CopyPlugin({
       patterns: [{ from: "./public", to: "./" }],


### PR DESCRIPTION
### What

Make sure to only export the envs needed

FYI: I confirmed that with the new configuration, the envs behavior still the same: they're loaded from .env if available, otherwise they are loaded from window._env_

### Why

📈 Kaizen