### PR TITLE
[SDP-1215] Disable the wallet toggle for in the WalletProviders screen unless the user has the owner role

### DIFF
--- a/src/components/WalletCard/index.tsx
+++ b/src/components/WalletCard/index.tsx
@@ -8,6 +8,7 @@ interface WalletCardProps {
   homepageUrl: string;
   enabled: boolean;
   assets: string[];
+  editable: boolean | null;
   onChange: () => void;
 }
 
@@ -17,6 +18,7 @@ export const WalletCard: React.FC<WalletCardProps> = ({
   homepageUrl,
   enabled,
   assets,
+  editable = true,
   onChange,
 }: WalletCardProps) => {
   return (
@@ -38,7 +40,12 @@ export const WalletCard: React.FC<WalletCardProps> = ({
               </div>
             </div>
 
-            <Toggle id={walletId} checked={enabled} onChange={onChange} />
+            <Toggle
+              id={walletId}
+              checked={enabled}
+              onChange={onChange}
+              disabled={!editable}
+            />
           </div>
         </div>
 

--- a/src/pages/WalletProviders.tsx
+++ b/src/pages/WalletProviders.tsx
@@ -16,12 +16,16 @@ import { ErrorWithExtras } from "components/ErrorWithExtras";
 
 import { useWallets } from "apiQueries/useWallets";
 import { useUpdateWallet } from "apiQueries/useUpdateWallet";
+import { useIsUserRoleAccepted } from "hooks/useIsUserRoleAccepted";
 import { ApiWallet } from "types";
 
 export const WalletProviders = () => {
   const [selectedWallet, setSelectedWallet] = useState<
     { id: string; enabled: boolean } | undefined
   >();
+  const { isRoleAccepted: canEditWalletProviders } = useIsUserRoleAccepted([
+    "owner",
+  ]);
 
   const {
     data: wallets,
@@ -70,6 +74,7 @@ export const WalletProviders = () => {
           homepageUrl={item.homepage}
           enabled={item.enabled}
           assets={item.assets?.map((asset) => asset.code)}
+          editable={canEditWalletProviders}
           onChange={() => {
             setSelectedWallet({ id: item.id, enabled: item.enabled });
 


### PR DESCRIPTION
### What
Disable the wallet toggle for in the WalletProviders screen unless the user has the owner role.

### Owner-role view

![Screenshot 2024-05-20 at 5 46 55 PM](https://github.com/stellar/stellar-disbursement-platform-frontend/assets/1952597/fc9a8f83-64a8-46d4-a7d6-191735be8618)


### Non-owner view

![Screenshot 2024-05-20 at 5 47 12 PM](https://github.com/stellar/stellar-disbursement-platform-frontend/assets/1952597/2861f1ac-2d18-45b1-8164-04b4150d7252)
