### PR TITLE
[Fix] Remove draft payments from remaining payments count when calculating % successful payments

### DIFF
--- a/src/components/DashboardAnalytics.tsx
+++ b/src/components/DashboardAnalytics.tsx
@@ -19,8 +19,8 @@ export const DashboardAnalytics = () => {
   } = useStatistics(userAccount.isAuthenticated);
 
   const calculateRate = () => {
-    if (stats?.paymentsSuccessfulCounts && stats?.paymentsTotalCount) {
-      return Number(stats.paymentsSuccessfulCounts / stats.paymentsTotalCount);
+    if (stats?.paymentsSuccessfulCounts && stats?.paymentsTotalCount && stats?.paymentsDraftCount) {
+      return Number(stats.paymentsSuccessfulCounts / (stats.paymentsTotalCount - stats.paymentsDraftCount));
     }
 
     return 0;

--- a/src/helpers/formatDisbursements.ts
+++ b/src/helpers/formatDisbursements.ts
@@ -24,6 +24,7 @@ export const formatDisbursement = (
     paymentsSuccessfulCount: disbursement.total_payments_sent,
     paymentsFailedCount: disbursement.total_payments_failed,
     paymentsCanceledCount: disbursement.total_payments_canceled,
+    paymentsDraftCount: disbursement.total_payments_draft,
     paymentsRemainingCount: disbursement.total_payments_remaining,
     paymentsTotalCount: disbursement.total_payments,
     totalAmount: disbursement.total_amount,

--- a/src/helpers/formatDisbursements.ts
+++ b/src/helpers/formatDisbursements.ts
@@ -24,7 +24,6 @@ export const formatDisbursement = (
     paymentsSuccessfulCount: disbursement.total_payments_sent,
     paymentsFailedCount: disbursement.total_payments_failed,
     paymentsCanceledCount: disbursement.total_payments_canceled,
-    paymentsDraftCount: disbursement.total_payments_draft,
     paymentsRemainingCount: disbursement.total_payments_remaining,
     paymentsTotalCount: disbursement.total_payments,
     totalAmount: disbursement.total_amount,

--- a/src/helpers/formatStatistics.ts
+++ b/src/helpers/formatStatistics.ts
@@ -5,6 +5,7 @@ export const formatStatistics = (statistics: ApiStatistics): HomeStatistics => {
     paymentsSuccessfulCounts: statistics.payment_counters.success,
     paymentsFailedCount: statistics.payment_counters.failed,
     paymentsCanceledCount: statistics.payment_counters.canceled,
+    paymentsDraftCount: statistics.payment_counters.draft,
     paymentsRemainingCount: Number(
       statistics.payment_counters.total -
         statistics.payment_counters.success -

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -573,6 +573,7 @@ export type ApiDisbursement = {
   total_payments_sent: number;
   total_payments_failed: number;
   total_payments_canceled: number;
+  total_payments_draft: number;
   total_payments_remaining: number;
   amount_disbursed: string;
   total_amount: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -573,7 +573,6 @@ export type ApiDisbursement = {
   total_payments_sent: number;
   total_payments_failed: number;
   total_payments_canceled: number;
-  total_payments_draft: number;
   total_payments_remaining: number;
   amount_disbursed: string;
   total_amount: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -437,6 +437,7 @@ export type HomeStatistics = {
   paymentsSuccessfulCounts: number;
   paymentsFailedCount: number;
   paymentsCanceledCount: number;
+  paymentsDraftCount: number;
   paymentsRemainingCount: number;
   paymentsTotalCount: number;
   walletsTotalCount: number;


### PR DESCRIPTION
When calculating the successful payments percentage, we need to remove draft payments count from the total payments count in the divisor.

for ex,
<img width="397" alt="Screenshot 2024-08-10 at 8 17 06 AM" src="https://github.com/user-attachments/assets/8f41a9c0-0136-497a-b70c-d1fabf028920">
<img width="1152" alt="Screenshot 2024-08-10 at 8 17 19 AM" src="https://github.com/user-attachments/assets/94e0c438-7c0a-4d4f-a387-1df361642e68">

here, the `DRAFT` payment does not count towards the divisor, so the successful payment rate is 1/1 = 100%

<img width="394" alt="Screenshot 2024-08-10 at 8 20 48 AM" src="https://github.com/user-attachments/assets/0ee71ccf-d11a-482e-b4d8-0cb7629989bb">
<img width="1151" alt="Screenshot 2024-08-10 at 8 20 57 AM" src="https://github.com/user-attachments/assets/f7107751-6d9e-4a07-a874-dd47bc563875">

here, a `READY` payment is added to the divisor, so the successful payment rate is 1/2 = 50%