### PR TITLE
[Fix] Do not allow selection of asset that does not have an account trustline / balance

### DIFF
--- a/src/apiQueries/useCircleBalances.ts
+++ b/src/apiQueries/useCircleBalances.ts
@@ -3,7 +3,7 @@ import { API_URL } from "constants/envVariables";
 import { fetchApi } from "helpers/fetchApi";
 import { AppError } from "types";
 
-export type BalancesApi = {
+type BalancesApi = {
   account: {
     circle_wallet_id: string;
     status: string;

--- a/src/apiQueries/useCircleBalances.ts
+++ b/src/apiQueries/useCircleBalances.ts
@@ -3,7 +3,7 @@ import { API_URL } from "constants/envVariables";
 import { fetchApi } from "helpers/fetchApi";
 import { AppError } from "types";
 
-type BalancesApi = {
+export type BalancesApi = {
   account: {
     circle_wallet_id: string;
     status: string;


### PR DESCRIPTION
Restricting selection of assets that have trustlines and balances during the disbursement upload process will prevent us from creating draft disbursements where payments cannot be started.

For native accounts,
with only native XLM
<img width="761" alt="Screenshot 2024-08-14 at 11 26 53 AM" src="https://github.com/user-attachments/assets/3f879795-f5f9-4b6b-b8d2-821fb796000d">

after adding trustline for USDC
<img width="599" alt="Screenshot 2024-08-14 at 11 34 21 AM" src="https://github.com/user-attachments/assets/4331a3e9-1b32-430a-81de-4dbbbc132f20">

<img width="651" alt="Screenshot 2024-08-14 at 11 31 19 AM" src="https://github.com/user-attachments/assets/9da1d00f-901d-4a44-a9a7-009669670959">

after adding asset that's not whitelisted
<img width="615" alt="Screenshot 2024-08-14 at 2 19 00 PM" src="https://github.com/user-attachments/assets/56244be7-c605-4553-ac70-7a1d2778c9ec">

for USDC Circle account
<img width="652" alt="Screenshot 2024-08-14 at 11 56 55 AM" src="https://github.com/user-attachments/assets/3395fdb8-093c-4cb2-80ac-8dad2d29c3fe">
