### PR TITLE
[SDP-1323] Fix bug introduced in PR #134 where the upload csv button would never be enabled

### DIFF
--- a/src/components/DisbursementDetails/index.tsx
+++ b/src/components/DisbursementDetails/index.tsx
@@ -332,11 +332,11 @@ export const DisbursementDetails: React.FC<DisbursementDetailsProps> = ({
           {walletAssets
             ?.filter((wa: ApiAsset) => {
               // Check for the default native asset
-              if (wa.code == "XLM") {
-                return wa;
+              if (wa.code == "XLM" && wa.issuer == "") {
+                return true;
               }
-              // Check that the asset is non-native asset that has a distribution account balance
-              return allBalances?.find(
+              // Check that the asset is a non-native asset that has a distribution account balance
+              return !!allBalances?.find(
                 (balance) =>
                   balance.assetCode === wa.code &&
                   balance.assetIssuer === wa.issuer,

--- a/src/components/DisbursementDetails/index.tsx
+++ b/src/components/DisbursementDetails/index.tsx
@@ -332,7 +332,7 @@ export const DisbursementDetails: React.FC<DisbursementDetailsProps> = ({
           {walletAssets
             ?.filter((wa: ApiAsset) => {
               // Check for the default native asset
-              if (wa.code == "XLM" && wa.issuer == "") {
+              if (wa.code === "XLM" && wa.issuer === "") {
                 return true;
               }
               // Check that the asset is a non-native asset that has a distribution account balance

--- a/src/components/DisbursementDetails/index.tsx
+++ b/src/components/DisbursementDetails/index.tsx
@@ -328,6 +328,7 @@ export const DisbursementDetails: React.FC<DisbursementDetailsProps> = ({
           value={details.asset.id}
           disabled={isWalletAssetsFetching || !details.wallet.id}
         >
+          {renderDropdownDefault(isWalletAssetsFetching)}
           {walletAssets
             ?.filter((wa: ApiAsset) => {
               // Check for the default native asset


### PR DESCRIPTION
### What

Fix bug introduced in PR #134 where the upload csv button would never be enabled.

### Why

The bug was caused because the PR removed the `{renderDropdownDefault(isWalletAssetsFetching)}` line of code that inserts the (initial) "empty dropdown value" to the dropdown list, and it resulted in preventing the _dropdown selection changed_ event from being called when the assets dropdown list contained a single item. That mistake prevents disbursement instructions from being uploaded.

### Additional Change(s)

Update the syntax of the javascript filter function to return explicit booleans.