### PR TITLE
[SDP-1316] Rename fields for receiver invitation template and interval

### DIFF
--- a/src/api/postDisbursement.ts
+++ b/src/api/postDisbursement.ts
@@ -20,7 +20,7 @@ export const postDisbursement = async (
       asset_id: disbursement.asset.id,
       country_code: disbursement.country.code,
       verification_field: disbursement.verificationField || "",
-      sms_registration_message_template:
+      receiver_registration_message_template:
         disbursement.smsRegistrationMessageTemplate,
     }),
   });

--- a/src/apiQueries/useUpdateOrgSmsRetryInterval.ts
+++ b/src/apiQueries/useUpdateOrgSmsRetryInterval.ts
@@ -8,7 +8,10 @@ export const useUpdateOrgSmsRetryInterval = () => {
     mutationFn: (retryInterval: number) => {
       const formData = new FormData();
 
-      formData.append("data", `{"sms_resend_interval": ${retryInterval}}`);
+      formData.append(
+        "data",
+        `{"receiver_invitation_resend_interval_days": ${retryInterval}}`,
+      );
 
       return fetchApi(
         `${API_URL}/organization`,

--- a/src/apiQueries/useUpdateOrgSmsTemplate.ts
+++ b/src/apiQueries/useUpdateOrgSmsTemplate.ts
@@ -10,7 +10,7 @@ export const useUpdateSmsTemplate = () => {
 
       formData.append(
         "data",
-        `{"sms_registration_message_template": "${template}"}`,
+        `{"receiver_registration_message_template": "${template}"}`,
       );
 
       return fetchApi(

--- a/src/helpers/formatDisbursements.ts
+++ b/src/helpers/formatDisbursements.ts
@@ -56,5 +56,5 @@ export const formatDisbursement = (
       userId: h.user_id,
     })),
   smsRegistrationMessageTemplate:
-    disbursement.sms_registration_message_template,
+    disbursement.receiver_registration_message_template,
 });

--- a/src/store/ducks/organization.ts
+++ b/src/store/ducks/organization.ts
@@ -168,8 +168,10 @@ const organizationSlice = createSlice({
         timezoneUtcOffset: action.payload.timezone_utc_offset,
         isApprovalRequired: action.payload.is_approval_required,
         smsRegistrationMessageTemplate:
-          action.payload.sms_registration_message_template,
-        smsResendInterval: Number(action.payload.sms_resend_interval || 0),
+          action.payload.receiver_registration_message_template,
+        smsResendInterval: Number(
+          action.payload.receiver_invitation_resend_interval_days || 0,
+        ),
         paymentCancellationPeriodDays: Number(
           action.payload.payment_cancellation_period_days || 0,
         ),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -557,7 +557,7 @@ export type ApiDisbursement = {
   status: DisbursementStatus;
   verification_field: DisbursementVerificationField;
   status_history: ApiDisbursementHistory[];
-  sms_registration_message_template: string;
+  receiver_registration_message_template: string;
   created_at: string;
   updated_at: string;
   created_by?: {
@@ -786,8 +786,8 @@ export type ApiOrgInfo = {
   distribution_account_public_key: string;
   timezone_utc_offset: string;
   is_approval_required: boolean;
-  sms_resend_interval: string;
-  sms_registration_message_template?: string;
+  receiver_invitation_resend_interval_days: string;
+  receiver_registration_message_template?: string;
   payment_cancellation_period_days: string;
   distribution_account?: {
     address?: string;


### PR DESCRIPTION
Rename the following fields for `organization` and `disbursement` 
* `sms_resend_interval` -> `receiver_invitation_resend_interval_days` 
* `sms_registration_message_template` -> `receiver_registration_message_template` 

This change is required to match the breaking change introduced in this PR https://github.com/stellar/stellar-disbursement-platform-backend/pull/412