### PR TITLE
[SDP-1369] Setup inter-dependency between dropdowns in the NewDisbursement screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "lint-staged": {
     "src/**/*.ts?(x)": [
-      "eslint --fix --max-warnings 0 --config eslint.config.mjs"
+      "eslint --fix --max-warnings 0"
     ]
   },
   "private": true,

--- a/src/apiQueries/useAssetsByWallet.ts
+++ b/src/apiQueries/useAssetsByWallet.ts
@@ -1,19 +1,29 @@
 import { useQuery } from "@tanstack/react-query";
 import { API_URL } from "constants/envVariables";
 import { fetchApi } from "helpers/fetchApi";
-import { ApiAsset, AppError } from "types";
+import { ApiAsset, AppError, hasWallet, RegistrationContactType } from "types";
 
-export const useAssetsByWallet = (walletId: string) => {
+export const useAssetsByWallet = ({
+  walletId,
+  registrationContactType,
+}: {
+  walletId: string | undefined;
+  registrationContactType: RegistrationContactType | undefined;
+}) => {
   const query = useQuery<ApiAsset[], AppError>({
-    queryKey: ["assets", "wallet", walletId],
+    queryKey: ["assets", "wallet", { walletId, registrationContactType }],
     queryFn: async () => {
-      if (!walletId) {
+      if (!walletId && !hasWallet(registrationContactType)) {
         return;
       }
+      const url = new URL(`${API_URL}/assets`);
+      if (walletId) {
+        url.searchParams.append("wallet", walletId);
+      }
 
-      return await fetchApi(`${API_URL}/assets?wallet=${walletId}`);
+      return await fetchApi(url.toString());
     },
-    enabled: Boolean(walletId),
+    enabled: Boolean(walletId) || hasWallet(registrationContactType),
   });
 
   return query;

--- a/src/components/DisbursementButtons/index.tsx
+++ b/src/components/DisbursementButtons/index.tsx
@@ -139,7 +139,7 @@ export const DisbursementButtons = ({
               Save as a draft
             </Button>
             <Button
-              variant="secondary"
+              variant="primary"
               size="xs"
               icon={<Icon.ArrowRight />}
               iconPosition="right"

--- a/src/components/DisbursementDetails/index.tsx
+++ b/src/components/DisbursementDetails/index.tsx
@@ -301,7 +301,12 @@ export const DisbursementDetails: React.FC<DisbursementDetailsProps> = ({
           fieldSize="sm"
           onChange={updateDraftDetails}
           value={details.wallet.id}
-          disabled={isWalletsLoading}
+          disabled={
+            isWalletsLoading ||
+            !registrationContactTypes ||
+            !details.registrationContactType ||
+            details.registrationContactType?.endsWith("WALLET_ADDRESS")
+          }
         >
           {renderDropdownDefault(isWalletsLoading)}
           {wallets &&
@@ -349,7 +354,12 @@ export const DisbursementDetails: React.FC<DisbursementDetailsProps> = ({
           fieldSize="sm"
           onChange={updateDraftDetails}
           value={details.verificationField}
-          disabled={isVerificationTypesFetching}
+          disabled={
+            isVerificationTypesFetching ||
+            !registrationContactTypes ||
+            !details.registrationContactType ||
+            details.registrationContactType?.endsWith("WALLET_ADDRESS")
+          }
         >
           {renderDropdownDefault(isVerificationTypesFetching)}
           {verificationTypes?.map((type: DisbursementVerificationField) => (

--- a/src/components/DisbursementDetails/index.tsx
+++ b/src/components/DisbursementDetails/index.tsx
@@ -120,12 +120,16 @@ export const DisbursementDetails: React.FC<DisbursementDetailsProps> = ({
       missingFields.push(FieldId.NAME);
     } else if (!inputs.registrationContactType) {
       missingFields.push(FieldId.REGISTRATION_CONTACT_TYPE);
-    } else if (!inputs.wallet.id) {
-      missingFields.push(FieldId.WALLET_ID);
     } else if (!inputs.asset.code) {
       missingFields.push(FieldId.ASSET_CODE);
-    } else if (!inputs.verificationField) {
-      missingFields.push(FieldId.VERIFICATION_FIELD);
+    }
+
+    if (!hasWallet(inputs.registrationContactType)) {
+      if (!inputs.wallet.id) {
+        missingFields.push(FieldId.WALLET_ID);
+      } else if (!inputs.verificationField) {
+        missingFields.push(FieldId.VERIFICATION_FIELD);
+      }
     }
 
     const isValid = missingFields.length === 0;

--- a/src/components/DisbursementDetails/index.tsx
+++ b/src/components/DisbursementDetails/index.tsx
@@ -160,7 +160,6 @@ export const DisbursementDetails: React.FC<DisbursementDetailsProps> = ({
 
     switch (id) {
       case FieldId.REGISTRATION_CONTACT_TYPE: {
-        // eslint-disable-next-line no-case-declarations
         const registrationContactType = registrationContactTypes?.find(
           (rct: RegistrationContactType) => rct === value,
         );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -495,6 +495,9 @@ export type RegistrationContactType =
   | "PHONE_NUMBER"
   | "PHONE_NUMBER_AND_WALLET_ADDRESS";
 
+export const hasWallet = (rct: RegistrationContactType | undefined): boolean =>
+  Boolean(rct?.endsWith("WALLET_ADDRESS"));
+
 export type ApiAsset = {
   id: string;
   code: string;


### PR DESCRIPTION
### What

Setup inter-dependency between dropdowns in the NewDisbursement screen:
- [x] When creating a disbursement, start with the registration type
- [x] Then Wallet provider. Which is disabled when the registration type ends with WALLET_ADDRESS
- [x] Then Asset. `GET /assets` should be fetched without the wallet_id when the registration type ends with WALLET_ADDRESS.
- [x] Then Verification type. Which is disabled when the registration type ends with WALLET_ADDRESS