### PR TITLE
[Fix] Make receiver verifications optional

### DIFF
--- a/src/helpers/formatReceiver.ts
+++ b/src/helpers/formatReceiver.ts
@@ -29,9 +29,10 @@ export const formatReceiver = (receiver: ApiReceiver): ReceiverDetails => ({
     // TODO: withdrawn amount
     withdrawnAmount: "",
   })),
-  verifications: receiver.verifications.map((v) => ({
-    verificationField: v.verification_field,
-    value: v.hashed_value,
-    confirmedAt: v.confirmed_at,
-  })),
+  verifications:
+    receiver.verifications?.map((v) => ({
+      verificationField: v.verification_field,
+      value: v.hashed_value,
+      confirmedAt: v.confirmed_at,
+    })) || [],
 });


### PR DESCRIPTION
Receiver verifications is an optional field after changes introduced in https://stellarorg.atlassian.net/browse/SDP-1222. 