### PR TITLE
Feat: Update GET /wallets with the `?user_managed={boolean}` query param

### DIFF
--- a/src/apiQueries/useWallets.ts
+++ b/src/apiQueries/useWallets.ts
@@ -3,11 +3,21 @@ import { API_URL } from "constants/envVariables";
 import { fetchApi } from "helpers/fetchApi";
 import { ApiWallet, AppError } from "types";
 
-export const useWallets = () => {
+type UseWalletsProps = {
+  userManaged?: boolean;
+};
+
+export const useWallets = ({ userManaged }: UseWalletsProps) => {
   const query = useQuery<ApiWallet[], AppError>({
     queryKey: ["wallets"],
     queryFn: async () => {
-      return await fetchApi(`${API_URL}/wallets`);
+      const url = new URL(`${API_URL}/wallets`);
+
+      if (userManaged !== undefined) {
+        url.searchParams.append("user_managed", userManaged.toString());
+      }
+
+      return await fetchApi(url.toString());
     },
   });
 

--- a/src/components/DisbursementDetails/index.tsx
+++ b/src/components/DisbursementDetails/index.tsx
@@ -78,7 +78,7 @@ export const DisbursementDetails: React.FC<DisbursementDetailsProps> = ({
     data: wallets,
     error: walletsError,
     isLoading: isWalletsLoading,
-  } = useWallets();
+  } = useWallets({ userManaged: false });
 
   const {
     data: registrationContactTypes,

--- a/src/pages/WalletProviders.tsx
+++ b/src/pages/WalletProviders.tsx
@@ -33,7 +33,7 @@ export const WalletProviders = () => {
     isPending: isWalletsPending,
     isFetching: isWalletsFetching,
     refetch: refetchWallets,
-  } = useWallets();
+  } = useWallets({});
 
   const {
     error: walletUpdateError,


### PR DESCRIPTION
- The Wallet Providers screen does not apply this query parameter and calls `GET /wallets` directly.
- The New Disbursement screen uses `GET /wallets?user_managed=false`