### PR TITLE
[SDP-1525] Surface external payment IDs

### DIFF
--- a/src/components/PaymentsTable.tsx
+++ b/src/components/PaymentsTable.tsx
@@ -98,7 +98,7 @@ export const PaymentsTable = ({
                 {/* <Table.BodyCell width="1rem">
                 <Checkbox id={`payment-${p.id}`} fieldSize="xs" />
               </Table.BodyCell> */}
-                <Table.BodyCell width="7.5rem" title={p.id}>
+                <Table.BodyCell width="14rem" title={p.id}>
                   <Link onClick={(event) => handlePaymentClicked(event, p.id)}>
                     <span className="PaymentIDs__item">{p.id}</span>
                     {p.external_payment_id ? (

--- a/src/components/PaymentsTable.tsx
+++ b/src/components/PaymentsTable.tsx
@@ -100,7 +100,12 @@ export const PaymentsTable = ({
               </Table.BodyCell> */}
                 <Table.BodyCell width="7.5rem" title={p.id}>
                   <Link onClick={(event) => handlePaymentClicked(event, p.id)}>
-                    {p.id}
+                    <span className="PaymentIDs__item">{p.id}</span>
+                    {p.external_payment_id ? (
+                      <span className="PaymentIDs__item">
+                        {p.external_payment_id}
+                      </span>
+                    ) : null}
                   </Link>
                 </Table.BodyCell>
                 <Table.BodyCell width="7.5rem" allowOverflow>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -363,6 +363,16 @@ body {
   }
 }
 
+// Payments
+.PaymentIDs {
+  &__item {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
 // Payment details
 .PaymentDetails {
   &__wrapper {


### PR DESCRIPTION
### Changes
- Surface External Payment IDs on the payment listing page
- Increase size of payment ID column. 

<img width="1242" alt="Screenshot 2025-01-24 at 9 05 59 PM" src="https://github.com/user-attachments/assets/90409606-f02b-464b-9895-0b7c3df048f7" />

