### PR TITLE
[SDP-1528] Add option to enable short linking from the settings page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 > Place unreleased changes here.
 
+## [3.5.0 UNRELEASED](https://github.com/stellar/stellar-disbursement-platform-frontend/releases/tag/3.5.0) ([diff](https://github.com/stellar/stellar-disbursement-platform-frontend/compare/3.4.0...3.5.0))
+
+### Added
+
+- Added option to enable short linking in the Settings page.
+  [#230](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/230)
+
 ## [3.4.0](https://github.com/stellar/stellar-disbursement-platform-frontend/releases/tag/3.4.0) ([diff](https://github.com/stellar/stellar-disbursement-platform-frontend/compare/3.3.0...3.4.0))
 
 > [!WARNING] This version is only compatible with the

--- a/src/apiQueries/useUpdateOrgShortLinkEnabled.ts
+++ b/src/apiQueries/useUpdateOrgShortLinkEnabled.ts
@@ -1,0 +1,36 @@
+import { useMutation } from "@tanstack/react-query";
+import { API_URL } from "constants/envVariables";
+import { fetchApi } from "helpers/fetchApi";
+import { AppError } from "types";
+
+export const useUpdateOrgShortLinkEnabled = () => {
+  const mutation = useMutation({
+    mutationFn: (isEnabled: boolean) => {
+      const formData = new FormData();
+
+      formData.append("data", `{"is_link_shortener_enabled": ${isEnabled}}`);
+
+      return fetchApi(
+        `${API_URL}/organization`,
+        {
+          method: "PATCH",
+          body: formData,
+        },
+        { omitContentType: true },
+      );
+    },
+  });
+
+  return {
+    ...mutation,
+    error: mutation.error as AppError,
+    data: mutation.data as { message: string },
+    mutateAsync: async (isEnabled: boolean) => {
+      try {
+        await mutation.mutateAsync(isEnabled);
+      } catch {
+        // do nothing
+      }
+    },
+  };
+};

--- a/src/components/SettingsEnableShortLinking.tsx
+++ b/src/components/SettingsEnableShortLinking.tsx
@@ -2,7 +2,6 @@ import { useEffect } from "react";
 import { Card, Notification, Toggle, Loader } from "@stellar/design-system";
 import { useDispatch } from "react-redux";
 
-import { API_URL } from "constants/envVariables";
 import { ErrorWithExtras } from "components/ErrorWithExtras";
 
 import { useUpdateOrgShortLinkEnabled } from "apiQueries/useUpdateOrgShortLinkEnabled";
@@ -51,7 +50,8 @@ export const SettingsEnableShortLinking = () => {
           </div>
           <div className="Note">
             Select this option to use shorter links when inviting receivers. The
-            short link format will look like <code>{API_URL}/r/abcd1234</code>.
+            short link format will look like{" "}
+            <code>{organization.data.baseUrl}/r/abcd1234</code>.
           </div>
         </div>
       </div>

--- a/src/components/SettingsEnableShortLinking.tsx
+++ b/src/components/SettingsEnableShortLinking.tsx
@@ -49,7 +49,7 @@ export const SettingsEnableShortLinking = () => {
             </div>
           </div>
           <div className="Note">
-            Select this option to use short links when inviting receivers. The
+            Select this option to use shorter links when inviting receivers. The
             short link format will look like{" "}
             <code>https://[your_domain]/r/abcd1234</code>.
           </div>

--- a/src/components/SettingsEnableShortLinking.tsx
+++ b/src/components/SettingsEnableShortLinking.tsx
@@ -1,0 +1,74 @@
+import { useEffect } from "react";
+import { Card, Notification, Toggle, Loader } from "@stellar/design-system";
+import { useDispatch } from "react-redux";
+
+import { ErrorWithExtras } from "components/ErrorWithExtras";
+
+import { useUpdateOrgShortLinkEnabled } from "apiQueries/useUpdateOrgShortLinkEnabled";
+import { useRedux } from "hooks/useRedux";
+import { AppDispatch } from "store";
+import { getOrgInfoAction } from "store/ducks/organization";
+
+export const SettingsEnableShortLinking = () => {
+  const { organization } = useRedux("organization");
+
+  const dispatch: AppDispatch = useDispatch();
+
+  const { mutateAsync, isPending, error, isSuccess } =
+    useUpdateOrgShortLinkEnabled();
+
+  useEffect(() => {
+    if (isSuccess) {
+      dispatch(getOrgInfoAction());
+    }
+  }, [dispatch, isSuccess]);
+
+  const handleToggleChange = () => {
+    mutateAsync(!organization.data.isLinkShortenerEnabled);
+  };
+
+  const renderContent = () => {
+    return (
+      <div className="SdpSettings">
+        <div className="SdpSettings__row">
+          <div className="SdpSettings__item">
+            <label
+              className="SdpSettings__label"
+              htmlFor="payment-cancellation"
+            >
+              Enable short linking
+            </label>
+            <div className="Toggle__wrapper">
+              {isPending ? <Loader size="1rem" /> : null}
+              <Toggle
+                id="payment-cancellation"
+                checked={Boolean(organization.data.isLinkShortenerEnabled)}
+                onChange={handleToggleChange}
+                disabled={isPending}
+              />
+            </div>
+          </div>
+          <div className="Note">
+            Select this option to use short links when inviting receivers. The
+            short link format will look like{" "}
+            <code>https://[your_domain]/r/abcd1234</code>.
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <>
+      {error ? (
+        <Notification variant="error" title="Error">
+          <ErrorWithExtras appError={error} />
+        </Notification>
+      ) : null}
+
+      <Card>
+        <div className="CardStack__card">{renderContent()}</div>
+      </Card>
+    </>
+  );
+};

--- a/src/components/SettingsEnableShortLinking.tsx
+++ b/src/components/SettingsEnableShortLinking.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { Card, Notification, Toggle, Loader } from "@stellar/design-system";
 import { useDispatch } from "react-redux";
 
+import { API_URL } from "constants/envVariables";
 import { ErrorWithExtras } from "components/ErrorWithExtras";
 
 import { useUpdateOrgShortLinkEnabled } from "apiQueries/useUpdateOrgShortLinkEnabled";
@@ -50,8 +51,7 @@ export const SettingsEnableShortLinking = () => {
           </div>
           <div className="Note">
             Select this option to use shorter links when inviting receivers. The
-            short link format will look like{" "}
-            <code>https://[your_domain]/r/abcd1234</code>.
+            short link format will look like <code>{API_URL}/r/abcd1234</code>.
           </div>
         </div>
       </div>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -3,8 +3,9 @@ import { Heading } from "@stellar/design-system";
 import { SectionHeader } from "components/SectionHeader";
 import { SettingsTeamMembers } from "components/SettingsTeamMembers";
 import { ReceiverInviteMessage } from "components/ReceiverInviteMessage";
-import { SettingsEnableReceiverInvitationRetry } from "components/SettingsEnableReceiverInvitationRetry";
+import { SettingsEnableShortLinking } from "components/SettingsEnableShortLinking";
 import { SettingsEnablePaymentCancellation } from "components/SettingsEnablePaymentCancellation";
+import { SettingsEnableReceiverInvitationRetry } from "components/SettingsEnableReceiverInvitationRetry";
 
 export const Settings = () => {
   return (
@@ -20,6 +21,9 @@ export const Settings = () => {
       </SectionHeader>
 
       <div className="CardStack">
+        {/* Enable short link */}
+        <SettingsEnableShortLinking />
+
         {/* Enable automatic ready payments cancellation */}
         <SettingsEnablePaymentCancellation />
 

--- a/src/store/ducks/organization.ts
+++ b/src/store/ducks/organization.ts
@@ -132,6 +132,7 @@ const initialState: OrganizationInitialState = {
     isApprovalRequired: undefined,
     receiverInvitationResendInterval: 0,
     paymentCancellationPeriodDays: 0,
+    isLinkShortenerEnabled: false,
   },
   updateMessage: undefined,
   status: undefined,
@@ -169,6 +170,7 @@ const organizationSlice = createSlice({
         isApprovalRequired: action.payload.is_approval_required,
         receiverRegistrationMessageTemplate:
           action.payload.receiver_registration_message_template,
+        isLinkShortenerEnabled: action.payload.is_link_shortener_enabled,
         receiverInvitationResendInterval: Number(
           action.payload.receiver_invitation_resend_interval_days || 0,
         ),

--- a/src/store/ducks/organization.ts
+++ b/src/store/ducks/organization.ts
@@ -133,6 +133,7 @@ const initialState: OrganizationInitialState = {
     receiverInvitationResendInterval: 0,
     paymentCancellationPeriodDays: 0,
     isLinkShortenerEnabled: false,
+    baseUrl: "",
   },
   updateMessage: undefined,
   status: undefined,
@@ -171,6 +172,7 @@ const organizationSlice = createSlice({
         receiverRegistrationMessageTemplate:
           action.payload.receiver_registration_message_template,
         isLinkShortenerEnabled: action.payload.is_link_shortener_enabled,
+        baseUrl: action.payload.base_url,
         receiverInvitationResendInterval: Number(
           action.payload.receiver_invitation_resend_interval_days || 0,
         ),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -71,6 +71,7 @@ export type OrganizationInitialState = {
     isApprovalRequired: boolean | undefined;
     receiverInvitationResendInterval: number;
     receiverRegistrationMessageTemplate?: string;
+    isLinkShortenerEnabled: boolean;
     paymentCancellationPeriodDays: number;
     distributionAccount?: {
       circleWalletId?: string;
@@ -815,6 +816,7 @@ export type ApiOrgInfo = {
   is_approval_required: boolean;
   receiver_invitation_resend_interval_days: string;
   receiver_registration_message_template?: string;
+  is_link_shortener_enabled: boolean;
   payment_cancellation_period_days: string;
   distribution_account?: {
     address?: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -72,6 +72,7 @@ export type OrganizationInitialState = {
     receiverInvitationResendInterval: number;
     receiverRegistrationMessageTemplate?: string;
     isLinkShortenerEnabled: boolean;
+    baseUrl: string;
     paymentCancellationPeriodDays: number;
     distributionAccount?: {
       circleWalletId?: string;
@@ -817,6 +818,7 @@ export type ApiOrgInfo = {
   receiver_invitation_resend_interval_days: string;
   receiver_registration_message_template?: string;
   is_link_shortener_enabled: boolean;
+  base_url: string;
   payment_cancellation_period_days: string;
   distribution_account?: {
     address?: string;


### PR DESCRIPTION
### What

Add option to enable short linking from the settings page.

<img width="626" alt="Screenshot 2025-02-03 at 4 18 45 PM" src="https://github.com/user-attachments/assets/c0be0f92-88ea-4904-a83d-3bb3301d1394" />

### Why

- To reduce the cost of SMS messages.
- To have a more reliable experience (long links are scarry).
