### PR TITLE
Fix: rename variable `is_tenant_memo_enabled` to `is_memo_tracing_enabled`

### DIFF
--- a/src/apiQueries/useUpdateOrgMemoTrackingEnabled.ts
+++ b/src/apiQueries/useUpdateOrgMemoTrackingEnabled.ts
@@ -8,7 +8,7 @@ export const useUpdateOrgMemoTrackingEnabled = () => {
     mutationFn: (isEnabled: boolean) => {
       const formData = new FormData();
 
-      formData.append("data", `{"is_tenant_memo_enabled": ${isEnabled}}`);
+      formData.append("data", `{"is_memo_tracing_enabled": ${isEnabled}}`);
 
       return fetchApi(
         `${API_URL}/organization`,

--- a/src/components/SettingsEnableMemoTracking.tsx
+++ b/src/components/SettingsEnableMemoTracking.tsx
@@ -24,7 +24,7 @@ export const SettingsEnableMemoTracking = () => {
   }, [dispatch, isSuccess]);
 
   const handleToggleChange = () => {
-    mutateAsync(!organization.data.isMemoTrackingEnabled);
+    mutateAsync(!organization.data.isMemoTracingEnabled);
   };
 
   const renderContent = () => {
@@ -39,7 +39,7 @@ export const SettingsEnableMemoTracking = () => {
               {isPending ? <Loader size="1rem" /> : null}
               <Toggle
                 id="memo-tracing-toggle"
-                checked={Boolean(organization.data.isMemoTrackingEnabled)}
+                checked={Boolean(organization.data.isMemoTracingEnabled)}
                 onChange={handleToggleChange}
                 disabled={isPending}
               />

--- a/src/store/ducks/organization.ts
+++ b/src/store/ducks/organization.ts
@@ -133,7 +133,7 @@ const initialState: OrganizationInitialState = {
     receiverInvitationResendInterval: 0,
     paymentCancellationPeriodDays: 0,
     isLinkShortenerEnabled: false,
-    isMemoTrackingEnabled: false,
+    isMemoTracingEnabled: false,
     baseUrl: "",
   },
   updateMessage: undefined,
@@ -173,7 +173,7 @@ const organizationSlice = createSlice({
         receiverRegistrationMessageTemplate:
           action.payload.receiver_registration_message_template,
         isLinkShortenerEnabled: action.payload.is_link_shortener_enabled,
-        isMemoTrackingEnabled: action.payload.is_tenant_memo_enabled,
+        isMemoTracingEnabled: action.payload.is_memo_tracing_enabled,
         baseUrl: action.payload.base_url,
         receiverInvitationResendInterval: Number(
           action.payload.receiver_invitation_resend_interval_days || 0,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -72,7 +72,7 @@ export type OrganizationInitialState = {
     receiverInvitationResendInterval: number;
     receiverRegistrationMessageTemplate?: string;
     isLinkShortenerEnabled: boolean;
-    isMemoTrackingEnabled: boolean;
+    isMemoTracingEnabled: boolean;
     baseUrl: string;
     paymentCancellationPeriodDays: number;
     distributionAccount?: {
@@ -819,7 +819,7 @@ export type ApiOrgInfo = {
   receiver_invitation_resend_interval_days: string;
   receiver_registration_message_template?: string;
   is_link_shortener_enabled: boolean;
-  is_tenant_memo_enabled: boolean;
+  is_memo_tracing_enabled: boolean;
   base_url: string;
   payment_cancellation_period_days: string;
   distribution_account?: {


### PR DESCRIPTION
### What

Rename variable `is_tenant_memo_enabled` to `is_memo_tracing_enabled`.

### Why

This was renamed in the backend and I forgot to rename it in the FE as well.