### PR TITLE
[SDP-1496] Improve UX on the fogotPassword->resetPassword flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## [3.6.0 UNRELEASED](https://github.com/stellar/stellar-disbursement-platform-frontend/releases/tag/3.6.0) ([diff](https://github.com/stellar/stellar-disbursement-platform-frontend/compare/3.5.0...3.6.0))
 
-> Place unreleased changes here.
+### Changed
+
+- Improve UX on the reset-password flow by parsing the reset token in the URL,
+  which reduces human intervention.
+  [#239](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/239)
 
 ## [3.5.0](https://github.com/stellar/stellar-disbursement-platform-frontend/releases/tag/3.5.0) ([diff](https://github.com/stellar/stellar-disbursement-platform-frontend/compare/3.4.0...3.5.0))
 

--- a/src/pages/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword.tsx
@@ -68,7 +68,7 @@ export const ForgotPassword = () => {
     <>
       <div className="CardLayout">
         {isSuccess ? (
-          <Notification variant="success" title="Password reset email sent">
+          <Notification variant="success" title="Password reset requested">
             {data?.message}
           </Notification>
         ) : null}

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -18,6 +18,15 @@ import { InfoTooltip } from "components/InfoTooltip";
 import { ErrorWithExtras } from "components/ErrorWithExtras";
 
 export const ResetPassword = () => {
+  // Get token from URL params
+  const [searchParams] = useSearchParams();
+  useEffect(() => {
+    const token = searchParams.get("token");
+    if (token) {
+      setConfirmationToken(token);
+    }
+  }, [searchParams]);
+
   const { isSuccess, isPending, error, mutateAsync, reset } =
     useResetPassword();
 

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -6,7 +6,7 @@ import {
   Notification,
   Link,
 } from "@stellar/design-system";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 
 import { SINGLE_TENANT_MODE } from "constants/envVariables";
 import { ORG_NAME_INFO_TEXT } from "constants/settings";
@@ -39,7 +39,6 @@ export const ResetPassword = () => {
 
   const [errorPassword, setErrorPassword] = useState("");
   const [errorPasswordMatch, setErrorPasswordMatch] = useState("");
-  const [errorConfirmationToken, setErrorConfirmationToken] = useState("");
 
   const handleResetPassword = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -62,14 +61,8 @@ export const ResetPassword = () => {
     navigate("/");
   };
 
-  const validateConfirmationToken = () => {
-    setErrorConfirmationToken(
-      confirmationToken ? "" : "Confirmation token is required",
-    );
-  };
-
   const allInputsValid = () => {
-    if (errorPassword || errorPasswordMatch || errorConfirmationToken) {
+    if (errorPassword || errorPasswordMatch) {
       return false;
     } else if (
       organizationName &&
@@ -136,20 +129,6 @@ export const ResetPassword = () => {
               type="text"
             />
           )}
-
-          <Input
-            fieldSize="sm"
-            id="rp-token"
-            name="rp-token"
-            label="Confirmation token"
-            onChange={(e) => {
-              setErrorConfirmationToken("");
-              setConfirmationToken(e.target.value);
-            }}
-            onBlur={validateConfirmationToken}
-            value={confirmationToken}
-            error={errorConfirmationToken}
-          />
 
           <Input
             fieldSize="sm"


### PR DESCRIPTION
### What

Improve UX on the fogotPassword->resetPassword flow:
- The reset-password page now parses a query parameter from the URL: `?token={confirmation-token}`
- Since the reset token is parsed from the URL, we don't need the token field anymore.

### Screenshots

#### Now

<img width="446" alt="Screenshot 2025-02-18 at 2 32 37 PM" src="https://github.com/user-attachments/assets/aa8e6028-d890-47f0-89d0-1628f23c220b" />

#### Before

<img width="430" alt="Screenshot 2025-02-18 at 2 33 32 PM" src="https://github.com/user-attachments/assets/2a7243a3-e2b8-4571-a3c6-a4f9f6e7d51c" />
