### PR TITLE
[SDP-1549] Make `Confirm Disbursement` atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Prettify the disbursement status text in the Disbursements table, similar to
   the payment status in the payment table.
   [#240](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/240)
+- Change the `Confirm Disbursement` operation to be atomic. This change ensures
+  that the disbursement creation and instruction processing is done in a single
+  operation.
+  [#241](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/241)
 
 ## [3.5.0](https://github.com/stellar/stellar-disbursement-platform-frontend/releases/tag/3.5.0) ([diff](https://github.com/stellar/stellar-disbursement-platform-frontend/compare/3.4.0...3.5.0))
 

--- a/src/api/postDisbursement.ts
+++ b/src/api/postDisbursement.ts
@@ -14,16 +14,18 @@ export const postDisbursement = async (
       Authorization: `Bearer ${token}`,
       "SDP-Tenant-Name": getSdpTenantName(),
     },
-    body: JSON.stringify({
-      name: disbursement.name,
-      wallet_id: disbursement.wallet.id,
-      asset_id: disbursement.asset.id,
-      registration_contact_type: disbursement.registrationContactType,
-      verification_field: disbursement.verificationField || "",
-      receiver_registration_message_template:
-        disbursement.receiverRegistrationMessageTemplate,
-    }),
+    body: JSON.stringify(preparePostDisbursementData(disbursement)),
   });
 
   return handleApiResponse(response);
 };
+
+export const preparePostDisbursementData = (disbursement: Disbursement) => ({
+  name: disbursement.name,
+  wallet_id: disbursement.wallet.id,
+  asset_id: disbursement.asset.id,
+  registration_contact_type: disbursement.registrationContactType,
+  verification_field: disbursement.verificationField || "",
+  receiver_registration_message_template:
+    disbursement.receiverRegistrationMessageTemplate,
+});

--- a/src/api/postDisbursementWithInstructions.ts
+++ b/src/api/postDisbursementWithInstructions.ts
@@ -2,6 +2,7 @@ import { handleApiResponse } from "api/handleApiResponse";
 import { API_URL } from "constants/envVariables";
 import { getSdpTenantName } from "helpers/getSdpTenantName";
 import { ApiDisbursement, Disbursement } from "types";
+import { preparePostDisbursementData } from "./postDisbursement";
 
 export const postDisbursementWithInstructions = async (
   token: string,
@@ -10,16 +11,7 @@ export const postDisbursementWithInstructions = async (
 ): Promise<ApiDisbursement> => {
   const formData = new FormData();
 
-  const data = {
-    name: disbursement.name,
-    wallet_id: disbursement.wallet.id,
-    asset_id: disbursement.asset.id,
-    registration_contact_type: disbursement.registrationContactType,
-    verification_field: disbursement.verificationField || "",
-    receiver_registration_message_template:
-      disbursement.receiverRegistrationMessageTemplate,
-  };
-
+  const data = preparePostDisbursementData(disbursement);
   formData.append("data", JSON.stringify(data));
   formData.append("file", file);
 

--- a/src/api/postDisbursementWithInstructions.ts
+++ b/src/api/postDisbursementWithInstructions.ts
@@ -1,0 +1,36 @@
+import { handleApiResponse } from "api/handleApiResponse";
+import { API_URL } from "constants/envVariables";
+import { getSdpTenantName } from "helpers/getSdpTenantName";
+import { ApiDisbursement, Disbursement } from "types";
+
+export const postDisbursementWithInstructions = async (
+  token: string,
+  disbursement: Disbursement,
+  file: File,
+): Promise<ApiDisbursement> => {
+  const formData = new FormData();
+
+  const data = {
+    name: disbursement.name,
+    wallet_id: disbursement.wallet.id,
+    asset_id: disbursement.asset.id,
+    registration_contact_type: disbursement.registrationContactType,
+    verification_field: disbursement.verificationField || "",
+    receiver_registration_message_template:
+      disbursement.receiverRegistrationMessageTemplate,
+  };
+
+  formData.append("data", JSON.stringify(data));
+  formData.append("file", file);
+
+  const response = await fetch(`${API_URL}/disbursements`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "SDP-Tenant-Name": getSdpTenantName(),
+    },
+    body: formData,
+  });
+
+  return handleApiResponse(response);
+};


### PR DESCRIPTION
### New Function Addition:
* Added `postDisbursementWithInstructions` function in `src/api/postDisbursementWithInstructions.ts` to handle disbursements with instructions and file uploads in a single atomic API call.

Matching backend change : https://github.com/stellar/stellar-disbursement-platform-backend/pull/554