### PR TITLE
SDP-1649: Fix receiver's XLM balance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Fixed
+
+-  Fix receiver's XLM balance [#258](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/258)
+
 ## [3.6.0](https://github.com/stellar/stellar-disbursement-platform-frontend/releases/tag/3.6.0) ([diff](https://github.com/stellar/stellar-disbursement-platform-frontend/compare/3.5.0...3.6.0))
 
 > [!WARNING]

--- a/src/components/ReceiverWalletBalance.tsx
+++ b/src/components/ReceiverWalletBalance.tsx
@@ -15,7 +15,9 @@ export const ReceiverWalletBalance = ({
     useStellarAccountInfo(stellarAddress);
 
   const balances =
-    data?.balances.filter((b) => b.asset_issuer && b.asset_code) || [];
+    data?.balances.filter(
+      (b) => b.asset_type == "native" || (b.asset_issuer && b.asset_code),
+    ) || [];
 
   if (stellarAddress && (isLoading || isFetching)) {
     return <Loader />;
@@ -36,8 +38,17 @@ export const ReceiverWalletBalance = ({
   return (
     <>
       {balances?.map((b, index) => (
-        <Fragment key={`${b.asset_code}-${b.asset_issuer}`}>
-          <AssetAmount assetCode={b.asset_code ?? ""} amount={b.balance} />
+        <Fragment
+          key={
+            b.asset_type === "native"
+              ? "native"
+              : `${b.asset_code}-${b.asset_issuer}`
+          }
+        >
+          <AssetAmount
+            assetCode={b.asset_type === "native" ? "XLM" : (b.asset_code ?? "")}
+            amount={b.balance}
+          />
           {index < balances.length - 1 ? ", " : null}
         </Fragment>
       ))}

--- a/src/components/ReceiverWalletBalance.tsx
+++ b/src/components/ReceiverWalletBalance.tsx
@@ -15,9 +15,7 @@ export const ReceiverWalletBalance = ({
     useStellarAccountInfo(stellarAddress);
 
   const balances =
-    data?.balances.filter(
-      (b) => b.asset_type == "native" || (b.asset_issuer && b.asset_code),
-    ) || [];
+    data?.balances.filter((b) => b.asset_type == "native" || b.asset_issuer && b.asset_code) || [];
 
   if (stellarAddress && (isLoading || isFetching)) {
     return <Loader />;
@@ -38,19 +36,13 @@ export const ReceiverWalletBalance = ({
   return (
     <>
       {balances?.map((b, index) => (
-        <Fragment
-          key={
-            b.asset_type === "native"
-              ? "native"
-              : `${b.asset_code}-${b.asset_issuer}`
-          }
-        >
-          <AssetAmount
-            assetCode={b.asset_type === "native" ? "XLM" : (b.asset_code ?? "")}
-            amount={b.balance}
-          />
-          {index < balances.length - 1 ? ", " : null}
-        </Fragment>
+        <Fragment key={b.asset_type === "native" ? "native" : `${b.asset_code}-${b.asset_issuer}`}>
+        <AssetAmount
+          assetCode={b.asset_type === "native" ? "XLM" : b.asset_code ?? ""}
+          amount={b.balance}
+        />
+        {index < balances.length - 1 ? ", " : null}
+      </Fragment>
       ))}
     </>
   );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -833,6 +833,7 @@ export type ApiOrgInfo = {
 export type ApiStellarAccountBalance = {
   asset_code?: string;
   asset_issuer?: string;
+  asset_type: string;
   balance: string;
 };
 


### PR DESCRIPTION
### What

If a receiver only has `XLM` balance, the balance field will show `-`. This is because the native asset does not have `asset_code` or `asset_issuer`. 

![image](https://github.com/user-attachments/assets/42e0f251-048c-442a-b115-74679ae430df)

### Why

We want to show asset balances.

### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] `CHANGELOG.md` is updated (if applicable)
- [x] Preview deployment works as expected
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Ready for production
