### PR TITLE
SDP-1610: Update receivers page for contract accounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@reduxjs/toolkit": "^2.4.0",
     "@stellar/design-system": "^1.1.3",
+    "@stellar/stellar-sdk": "^13.3.0",
     "@stellar/tsconfig": "^1.0.2",
     "@svgr/webpack": "8.1.0",
     "@tanstack/react-query": "^5.62.3",

--- a/src/apiQueries/useAccountBalances.ts
+++ b/src/apiQueries/useAccountBalances.ts
@@ -62,9 +62,10 @@ export const useAccountBalances = (stellarAddress: string | undefined) => {
     queryKey: ["account-balances", stellarAddress],
     queryFn: async () => {
       if (!stellarAddress) {
-        throw new Error("stellarAddress is required");
+        return [];
       }
 
+      // If the address is a Stellar address (starts with "G"), fetch from Horizon
       if (stellarAddress.startsWith("G")) {
         const accountInfo = await fetchStellarApi(
           `${HORIZON_URL}/accounts/${stellarAddress}`,
@@ -74,11 +75,8 @@ export const useAccountBalances = (stellarAddress: string | undefined) => {
           },
         );
         return accountInfo?.balances ?? [];
-      } else {
-        if (!RPC_URL || !API_URL) {
-          throw new Error("RPC_URL and API_URL are required for SAC balances");
-        }
-
+      } // If the address is a Stellar testnet address (starts with "C"), fetch from RPC
+      else {
         const assetsUrl = new URL(`${API_URL}/assets`);
         const assets: ApiAsset[] = await fetchApi(assetsUrl.toString());
 

--- a/src/apiQueries/useAccountBalances.ts
+++ b/src/apiQueries/useAccountBalances.ts
@@ -75,7 +75,7 @@ export const useAccountBalances = (stellarAddress: string | undefined) => {
           },
         );
         return accountInfo?.balances ?? [];
-      } // If the address is a Stellar testnet address (starts with "C"), fetch from RPC
+      } // If the address is a Stellar contract address (starts with "C"), fetch from RPC
       else {
         const assetsUrl = new URL(`${API_URL}/assets`);
         const assets: ApiAsset[] = await fetchApi(assetsUrl.toString());
@@ -88,7 +88,7 @@ export const useAccountBalances = (stellarAddress: string | undefined) => {
         } else if (passphrase === Networks.TESTNET) {
           network = Networks.TESTNET;
         } else {
-          network = Networks.TESTNET;
+          network = Networks.FUTURENET;
         }
 
         const balancePromises = assets.map((apiAsset) =>

--- a/src/apiQueries/useAccountBalances.ts
+++ b/src/apiQueries/useAccountBalances.ts
@@ -1,0 +1,111 @@
+import { useQuery } from "@tanstack/react-query";
+import { Asset, Networks, rpc } from "@stellar/stellar-sdk";
+import { API_URL, HORIZON_URL, RPC_URL } from "constants/envVariables";
+import { fetchApi } from "helpers/fetchApi";
+import { fetchStellarApi } from "helpers/fetchStellarApi";
+import { ApiStellarAccountBalance, AppError } from "types";
+
+const STROOP_CONVERSION_FACTOR = 10000000;
+
+interface ApiAsset {
+  id: string;
+  code: string;
+  issuer: string;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | null;
+}
+
+const getKnownBalances = async (
+  rpcServer: rpc.Server,
+  stellarAddress: string,
+  apiAsset: ApiAsset,
+  network: Networks,
+): Promise<ApiStellarAccountBalance> => {
+  const asset =
+    apiAsset.code === "XLM"
+      ? Asset.native()
+      : new Asset(apiAsset.code, apiAsset.issuer);
+
+  try {
+    const balance = await rpcServer.getSACBalance(
+      stellarAddress,
+      asset,
+      network,
+    );
+
+    const balanceAmount = balance?.balanceEntry?.amount
+      ? (
+          Number(balance.balanceEntry.amount) / STROOP_CONVERSION_FACTOR
+        ).toString()
+      : "0";
+
+    return {
+      asset_code: apiAsset.code,
+      asset_issuer: apiAsset.issuer,
+      asset_type: asset.getAssetType(),
+      balance: balanceAmount,
+    };
+  } catch {
+    // Return zero balance if fetching fails for a specific asset
+    return {
+      asset_code: apiAsset.code,
+      asset_issuer: apiAsset.issuer,
+      asset_type: asset.getAssetType(),
+      balance: "0",
+    };
+  }
+};
+
+export const useAccountBalances = (stellarAddress: string | undefined) => {
+  const query = useQuery<ApiStellarAccountBalance[], AppError>({
+    queryKey: ["account-balances", stellarAddress],
+    queryFn: async () => {
+      if (!stellarAddress) {
+        throw new Error("stellarAddress is required");
+      }
+
+      if (stellarAddress.startsWith("G")) {
+        const accountInfo = await fetchStellarApi(
+          `${HORIZON_URL}/accounts/${stellarAddress}`,
+          undefined,
+          {
+            notFoundMessage: `${stellarAddress} address was not found.`,
+          },
+        );
+        return accountInfo?.balances ?? [];
+      } else {
+        if (!RPC_URL || !API_URL) {
+          throw new Error("RPC_URL and API_URL are required for SAC balances");
+        }
+
+        const assetsUrl = new URL(`${API_URL}/assets`);
+        const assets: ApiAsset[] = await fetchApi(assetsUrl.toString());
+
+        const rpcServer = new rpc.Server(RPC_URL);
+        const passphrase = (await rpcServer.getNetwork()).passphrase;
+        let network: Networks;
+        if (passphrase === Networks.PUBLIC) {
+          network = Networks.PUBLIC;
+        } else if (passphrase === Networks.TESTNET) {
+          network = Networks.TESTNET;
+        } else {
+          network = Networks.TESTNET;
+        }
+
+        const balancePromises = assets.map((apiAsset) =>
+          getKnownBalances(rpcServer, stellarAddress, apiAsset, network),
+        );
+
+        return await Promise.all(balancePromises);
+      }
+    },
+    enabled:
+      Boolean(stellarAddress) &&
+      (stellarAddress!.startsWith("G")
+        ? Boolean(HORIZON_URL)
+        : Boolean(RPC_URL) && Boolean(API_URL)),
+  });
+
+  return query;
+};

--- a/src/apiQueries/useStellarAccountInfo.ts
+++ b/src/apiQueries/useStellarAccountInfo.ts
@@ -19,7 +19,7 @@ export const useStellarAccountInfo = (stellarAddress: string | undefined) => {
         },
       );
     },
-    enabled: Boolean(stellarAddress),
+    enabled: Boolean(stellarAddress) && stellarAddress?.startsWith("G"),
   });
 
   return query;

--- a/src/apiQueries/useStellarAccountInfo.ts
+++ b/src/apiQueries/useStellarAccountInfo.ts
@@ -19,7 +19,7 @@ export const useStellarAccountInfo = (stellarAddress: string | undefined) => {
         },
       );
     },
-    enabled: Boolean(stellarAddress) && stellarAddress?.startsWith("G"),
+    enabled: Boolean(stellarAddress),
   });
 
   return query;

--- a/src/components/ReceiverWalletBalance.tsx
+++ b/src/components/ReceiverWalletBalance.tsx
@@ -1,6 +1,6 @@
 import { Fragment } from "react";
 import { Loader, Notification } from "@stellar/design-system";
-import { useStellarAccountInfo } from "apiQueries/useStellarAccountInfo";
+import { useAccountBalances } from "apiQueries/useAccountBalances";
 import { AssetAmount } from "components/AssetAmount";
 import { ErrorWithExtras } from "components/ErrorWithExtras";
 
@@ -11,11 +11,17 @@ interface ReceiverWalletBalanceProps {
 export const ReceiverWalletBalance = ({
   stellarAddress,
 }: ReceiverWalletBalanceProps) => {
-  const { isLoading, isFetching, data, error } =
-    useStellarAccountInfo(stellarAddress);
+  const {
+    data: balances,
+    isLoading,
+    isFetching,
+    error,
+  } = useAccountBalances(stellarAddress);
 
-  const balances =
-    data?.balances.filter((b) => b.asset_issuer && b.asset_code) || [];
+  const displayBalances =
+    balances?.filter(
+      (b) => b.asset_type == "native" || (b.asset_issuer && b.asset_code),
+    ) || [];
 
   if (stellarAddress && (isLoading || isFetching)) {
     return <Loader />;
@@ -29,16 +35,25 @@ export const ReceiverWalletBalance = ({
     );
   }
 
-  if (balances?.length === 0) {
+  if (displayBalances?.length === 0) {
     return <>{"-"}</>;
   }
 
   return (
     <>
-      {balances?.map((b, index) => (
-        <Fragment key={`${b.asset_code}-${b.asset_issuer}`}>
-          <AssetAmount assetCode={b.asset_code ?? ""} amount={b.balance} />
-          {index < balances.length - 1 ? ", " : null}
+      {displayBalances?.map((b, index) => (
+        <Fragment
+          key={
+            b.asset_type === "native"
+              ? "native"
+              : `${b.asset_code}-${b.asset_issuer}`
+          }
+        >
+          <AssetAmount
+            assetCode={b.asset_type === "native" ? "XLM" : (b.asset_code ?? "")}
+            amount={b.balance}
+          />
+          {index < displayBalances.length - 1 ? ", " : null}
         </Fragment>
       ))}
     </>

--- a/src/components/ReceiverWalletBalance.tsx
+++ b/src/components/ReceiverWalletBalance.tsx
@@ -3,6 +3,8 @@ import { Loader, Notification } from "@stellar/design-system";
 import { useAccountBalances } from "apiQueries/useAccountBalances";
 import { AssetAmount } from "components/AssetAmount";
 import { ErrorWithExtras } from "components/ErrorWithExtras";
+import { RPC_URL } from "constants/envVariables";
+import { InfoTooltip } from "./InfoTooltip";
 
 interface ReceiverWalletBalanceProps {
   stellarAddress: string | undefined;
@@ -20,7 +22,9 @@ export const ReceiverWalletBalance = ({
 
   const displayBalances =
     balances?.filter(
-      (b) => b.asset_type == "native" || (b.asset_issuer && b.asset_code),
+      (b) =>
+        (b.asset_type == "native" || (b.asset_issuer && b.asset_code)) &&
+        parseFloat(b.balance) > 0,
     ) || [];
 
   if (stellarAddress && (isLoading || isFetching)) {
@@ -32,6 +36,17 @@ export const ReceiverWalletBalance = ({
       <Notification variant="error" title="Error">
         <ErrorWithExtras appError={error} />
       </Notification>
+    );
+  }
+
+  if (stellarAddress?.startsWith("C") && !RPC_URL) {
+    return (
+      <InfoTooltip
+        infoText="Fetching balances for this account is disabled"
+        placement="bottom"
+      >
+        Unavailable
+      </InfoTooltip>
     );
   }
 

--- a/src/components/ReceiverWalletBalance.tsx
+++ b/src/components/ReceiverWalletBalance.tsx
@@ -42,7 +42,7 @@ export const ReceiverWalletBalance = ({
   if (stellarAddress?.startsWith("C") && !RPC_URL) {
     return (
       <InfoTooltip
-        infoText="Fetching balances for this account is disabled"
+        infoText="Fetching balances is disabled. Please check with your technical support team to enable."
         placement="bottom"
       >
         Unavailable

--- a/src/constants/envVariables.ts
+++ b/src/constants/envVariables.ts
@@ -14,6 +14,7 @@ declare global {
       API_URL: string;
       STELLAR_EXPERT_URL: string;
       HORIZON_URL: string;
+      RPC_URL: string;
       RECAPTCHA_SITE_KEY: string;
       SINGLE_TENANT_MODE: boolean;
 
@@ -48,6 +49,7 @@ const generateEnvConfig = async () => {
       window._env_.STELLAR_EXPERT_URL,
     HORIZON_URL:
       process?.env?.REACT_APP_HORIZON_URL || window._env_.HORIZON_URL,
+    RPC_URL: process?.env?.REACT_APP_RPC_URL || window._env_.RPC_URL,
     RECAPTCHA_SITE_KEY:
       process?.env?.REACT_APP_RECAPTCHA_SITE_KEY ||
       window._env_.RECAPTCHA_SITE_KEY,
@@ -75,6 +77,7 @@ export const {
   API_URL,
   STELLAR_EXPERT_URL,
   HORIZON_URL,
+  RPC_URL,
   RECAPTCHA_SITE_KEY,
   SINGLE_TENANT_MODE,
   USE_SSO,

--- a/src/pages/ReceiverDetails.tsx
+++ b/src/pages/ReceiverDetails.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useState } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import {
+  Button,
   Card,
   Heading,
   Notification,
   Profile,
   Select,
-  Button,
 } from "@stellar/design-system";
 
 import { GENERIC_ERROR_MESSAGE, Routes } from "constants/settings";
@@ -33,7 +33,7 @@ import { formatDateTime } from "helpers/formatIntlDateTime";
 import { shortenAccountKey } from "helpers/shortenAccountKey";
 import { renderTextWithCount } from "helpers/renderTextWithCount";
 
-import { ReceiverWallet, ReceiverDetails as ReceiverDetailsType } from "types";
+import { ReceiverDetails as ReceiverDetailsType, ReceiverWallet } from "types";
 
 export const ReceiverDetails = () => {
   const { id: receiverId } = useParams();
@@ -162,9 +162,9 @@ export const ReceiverDetails = () => {
                   </InfoTooltip>
                 </div>
                 {/* TODO: add chart */}
-                <div className="StatCards__card__unit">{`${percent.format(
-                  calculateRate(),
-                )}`}</div>
+                <div className="StatCards__card__unit">
+                  {`${percent.format(calculateRate())}`}
+                </div>
               </div>
             </div>
 
@@ -328,7 +328,11 @@ export const ReceiverDetails = () => {
             <Card>
               <div
                 className="StatCards__card StatCards__card--grid StatCards__card--wideGap"
-                style={{ "--StatCard-grid-columns": 3 } as React.CSSProperties}
+                style={
+                  {
+                    "--StatCard-grid-columns": 3,
+                  } as React.CSSProperties
+                }
               >
                 {/* Column one */}
                 <div className="StatCards__card__column">
@@ -437,21 +441,23 @@ export const ReceiverDetails = () => {
               </div>
             </Card>
 
-            <div className="DetailsSection DetailsSection">
-              <SectionHeader>
-                <SectionHeader.Row>
-                  <SectionHeader.Content>
-                    <Heading as="h4" size="xs">
-                      Recent wallet history
-                    </Heading>
-                  </SectionHeader.Content>
-                </SectionHeader.Row>
-              </SectionHeader>
+            {selectedWallet.stellarAddress.startsWith("G") ? (
+              <div className="DetailsSection DetailsSection">
+                <SectionHeader>
+                  <SectionHeader.Row>
+                    <SectionHeader.Content>
+                      <Heading as="h4" size="xs">
+                        Recent wallet history
+                      </Heading>
+                    </SectionHeader.Content>
+                  </SectionHeader.Row>
+                </SectionHeader>
 
-              <ReceiverWalletHistory
-                stellarAddress={selectedWallet.stellarAddress}
-              />
-            </div>
+                <ReceiverWalletHistory
+                  stellarAddress={selectedWallet.stellarAddress}
+                />
+              </div>
+            ) : null}
           </>
         ) : null}
       </div>

--- a/src/pages/ReceiverDetails.tsx
+++ b/src/pages/ReceiverDetails.tsx
@@ -441,7 +441,7 @@ export const ReceiverDetails = () => {
               </div>
             </Card>
 
-            {selectedWallet.stellarAddress.startsWith("G") ? (
+            {selectedWallet.stellarAddress?.startsWith("G") ? (
               <div className="DetailsSection DetailsSection">
                 <SectionHeader>
                   <SectionHeader.Row>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -833,6 +833,7 @@ export type ApiOrgInfo = {
 export type ApiStellarAccountBalance = {
   asset_code?: string;
   asset_issuer?: string;
+  asset_type: string;
   balance: string;
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2398,6 +2398,39 @@
     react-copy-to-clipboard "^5.1.0"
     tslib "^2.5.0"
 
+"@stellar/js-xdr@^3.1.2":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@stellar/js-xdr/-/js-xdr-3.1.2.tgz#db7611135cf21e989602fd72f513c3bed621bc74"
+  integrity sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==
+
+"@stellar/stellar-base@^13.1.0":
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/@stellar/stellar-base/-/stellar-base-13.1.0.tgz#06d9075cc72da05bc5dd6f1971e6682a0525cec9"
+  integrity sha512-90EArG+eCCEzDGj3OJNoCtwpWDwxjv+rs/RNPhvg4bulpjN/CSRj+Ys/SalRcfM4/WRC5/qAfjzmJBAuquWhkA==
+  dependencies:
+    "@stellar/js-xdr" "^3.1.2"
+    base32.js "^0.1.0"
+    bignumber.js "^9.1.2"
+    buffer "^6.0.3"
+    sha.js "^2.3.6"
+    tweetnacl "^1.0.3"
+  optionalDependencies:
+    sodium-native "^4.3.3"
+
+"@stellar/stellar-sdk@^13.3.0":
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/@stellar/stellar-sdk/-/stellar-sdk-13.3.0.tgz#72bf3eea4797de053aaebb889bf4de342d0b6b54"
+  integrity sha512-8+GHcZLp+mdin8gSjcgfb/Lb6sSMYRX6Nf/0LcSJxvjLQR0XHpjGzOiRbYb2jSXo51EnA6kAV5j+4Pzh5OUKUg==
+  dependencies:
+    "@stellar/stellar-base" "^13.1.0"
+    axios "^1.8.4"
+    bignumber.js "^9.3.0"
+    eventsource "^2.0.2"
+    feaxios "^0.0.23"
+    randombytes "^2.1.0"
+    toml "^3.0.0"
+    urijs "^1.19.1"
+
 "@stellar/tsconfig@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@stellar/tsconfig/-/tsconfig-1.0.2.tgz#18e9b1a1d6076e116bb405d11fc034401155292d"
@@ -3484,6 +3517,11 @@ ast-types-flow@^0.0.8:
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.8.tgz#0a85e1c92695769ac13a428bb653e7538bea27d6"
   integrity sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 available-typed-arrays@^1.0.5, available-typed-arrays@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz#a5cc375d6a03c2efc87a553f3e0b1522def14846"
@@ -3495,6 +3533,15 @@ axe-core@^4.10.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.10.1.tgz#7d2589b0183f05b0f23e55c2f4cdf97b5bdc66d9"
   integrity sha512-qPC9o+kD8Tir0lzNGLeghbOrWMr3ZJpaRlCIb6Uobt/7N4FiEDvqUMnxzCHRHmg8vOg14kr5gVNyScRmbMaJ9g==
+
+axios@^1.8.4:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.9.0.tgz#25534e3b72b54540077d33046f77e3b8d7081901"
+  integrity sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 axobject-query@^4.1.0:
   version "4.1.0"
@@ -3590,6 +3637,50 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+bare-addon-resolve@^1.3.0:
+  version "1.9.4"
+  resolved "https://registry.yarnpkg.com/bare-addon-resolve/-/bare-addon-resolve-1.9.4.tgz#50ad7b26de493f978f09bbbbe987219c4ecbfd28"
+  integrity sha512-unn6Vy/Yke6F99vg/7tcrvM2KUvIhTNniaSqDbam4AWkd4NhvDVSrQiRYVlNzUV2P7SPobkCK7JFVxrJk9btCg==
+  dependencies:
+    bare-module-resolve "^1.10.0"
+    bare-semver "^1.0.0"
+
+bare-module-resolve@^1.10.0:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/bare-module-resolve/-/bare-module-resolve-1.10.2.tgz#c394a13ba1c9c06f7d59804fb62ab9550d3b0c0a"
+  integrity sha512-C9COe/GhWfVXKytW3DElTkiBU+Gb2OXeaVkdGdRB/lp26TVLESHkTGS876iceAGdvtPgohfp9nX8vXHGvN3++Q==
+  dependencies:
+    bare-semver "^1.0.0"
+
+bare-os@^3.0.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/bare-os/-/bare-os-3.6.1.tgz#9921f6f59edbe81afa9f56910658422c0f4858d4"
+  integrity sha512-uaIjxokhFidJP+bmmvKSgiMzj2sV5GPHaZVAIktcxcpCyBFFWO+YlikVAdhmUo2vYFvFhOXIAlldqV29L8126g==
+
+bare-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/bare-path/-/bare-path-3.0.0.tgz#b59d18130ba52a6af9276db3e96a2e3d3ea52178"
+  integrity sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==
+  dependencies:
+    bare-os "^3.0.1"
+
+bare-semver@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/bare-semver/-/bare-semver-1.0.1.tgz#4737d660785f07cb723cefa6b022089e59120a61"
+  integrity sha512-UtggzHLiTrmFOC/ogQ+Hy7VfoKoIwrP1UFcYtTxoCUdLtsIErT8+SWtOC2DH/snT9h+xDrcBEPcwKei1mzemgg==
+
+bare-url@^2.1.0:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/bare-url/-/bare-url-2.1.6.tgz#86937c11c29b094c821459d3041b7fa67322266e"
+  integrity sha512-FgjDeR+/yDH34By4I0qB5NxAoWv7dOTYcOXwn73kr+c93HyC2lU6tnjifqUe33LKMJcDyCYPQjEAqgOQiXkE2Q==
+  dependencies:
+    bare-path "^3.0.0"
+
+base32.js@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/base32.js/-/base32.js-0.1.0.tgz#b582dec693c2f11e893cf064ee6ac5b6131a2202"
+  integrity sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ==
+
 base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -3609,6 +3700,11 @@ bignumber.js@^9.1.1, bignumber.js@^9.1.2:
   version "9.1.2"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.2.tgz#b7c4242259c008903b13707983b5f4bbd31eda0c"
   integrity sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==
+
+bignumber.js@^9.3.0:
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.3.0.tgz#bdba7e2a4c1a2eba08290e8dcad4f36393c92acd"
+  integrity sha512-EM7aMFTXbptt/wZdMlBv2t8IViwQL+h6SLHosp8Yf0dqJMTnY6iL32opnAB6kAdL0SZPuvcAzFr31o0c/R3/RA==
 
 binary-extensions@^2.0.0:
   version "2.2.0"
@@ -3787,6 +3883,14 @@ bytes@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
+
+call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
+  integrity sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==
+  dependencies:
+    es-errors "^1.3.0"
+    function-bind "^1.1.2"
 
 call-bind@^1.0.0, call-bind@^1.0.2, call-bind@^1.0.5, call-bind@^1.0.6, call-bind@^1.0.7:
   version "1.0.7"
@@ -3967,6 +4071,13 @@ colorette@^2.0.10, colorette@^2.0.14, colorette@^2.0.20:
   version "2.0.20"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
   integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
+
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
 
 commander@^10.0.1:
   version "10.0.1"
@@ -4386,6 +4497,11 @@ del@^4.1.1:
     pify "^4.0.1"
     rimraf "^2.6.3"
 
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
+
 depd@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
@@ -4539,6 +4655,15 @@ dotenv@^16.4.7:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.7.tgz#0e20c5b82950140aa99be360a8a5f52335f53c26"
   integrity sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==
 
+dunder-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
+  integrity sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==
+  dependencies:
+    call-bind-apply-helpers "^1.0.1"
+    es-errors "^1.3.0"
+    gopd "^1.2.0"
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -4686,6 +4811,11 @@ es-define-property@^1.0.0:
   dependencies:
     get-intrinsic "^1.2.4"
 
+es-define-property@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.1.tgz#983eb2f9a6724e9303f61addf011c72e09e0b0fa"
+  integrity sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==
+
 es-errors@^1.2.1, es-errors@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
@@ -4723,6 +4853,13 @@ es-object-atoms@^1.0.0:
   dependencies:
     es-errors "^1.3.0"
 
+es-object-atoms@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz#1c4f2c4837327597ce69d2ca190a7fdd172338c1"
+  integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
+  dependencies:
+    es-errors "^1.3.0"
+
 es-set-tostringtag@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz#8bb60f0a440c2e4281962428438d58545af39777"
@@ -4731,6 +4868,16 @@ es-set-tostringtag@^2.0.3:
     get-intrinsic "^1.2.4"
     has-tostringtag "^1.0.2"
     hasown "^2.0.1"
+
+es-set-tostringtag@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz#f31dbbe0c183b00a6d26eb6325c810c0fd18bd4d"
+  integrity sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
+  dependencies:
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.6"
+    has-tostringtag "^1.0.2"
+    hasown "^2.0.2"
 
 es-shim-unscopables@^1.0.0, es-shim-unscopables@^1.0.2:
   version "1.0.2"
@@ -5071,6 +5218,11 @@ events@^3.2.0:
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
+eventsource@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-2.0.2.tgz#76dfcc02930fb2ff339520b6d290da573a9e8508"
+  integrity sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==
+
 evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"
@@ -5202,6 +5354,13 @@ faye-websocket@^0.11.3:
   dependencies:
     websocket-driver ">=0.5.1"
 
+feaxios@^0.0.23:
+  version "0.0.23"
+  resolved "https://registry.yarnpkg.com/feaxios/-/feaxios-0.0.23.tgz#76f37a2666232377ce75354e46dd85cbceeb1758"
+  integrity sha512-eghR0A21fvbkcQBgZuMfQhrXxJzC0GNUGC9fXhBge33D+mFDTwl0aJ35zoQQn575BhyjQitRc5N4f+L4cP708g==
+  dependencies:
+    is-retry-allowed "^3.0.0"
+
 file-entry-cache@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-8.0.0.tgz#7787bddcf1131bffb92636c69457bbc0edd6d81f"
@@ -5271,6 +5430,11 @@ follow-redirects@^1.0.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
   integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
 
+follow-redirects@^1.15.6:
+  version "1.15.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
+  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
+
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
@@ -5295,6 +5459,16 @@ fork-ts-checker-webpack-plugin@^9.0.2:
     schema-utils "^3.1.1"
     semver "^7.3.5"
     tapable "^2.2.1"
+
+form-data@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.2.tgz#35cabbdd30c3ce73deb2c42d3c8d3ed9ca51794c"
+  integrity sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    mime-types "^2.1.12"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -5375,6 +5549,30 @@ get-intrinsic@^1.1.3, get-intrinsic@^1.2.1, get-intrinsic@^1.2.3, get-intrinsic@
     has-proto "^1.0.1"
     has-symbols "^1.0.3"
     hasown "^2.0.0"
+
+get-intrinsic@^1.2.6:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
+  integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    es-define-property "^1.0.1"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.1.1"
+    function-bind "^1.1.2"
+    get-proto "^1.0.1"
+    gopd "^1.2.0"
+    has-symbols "^1.1.0"
+    hasown "^2.0.2"
+    math-intrinsics "^1.1.0"
+
+get-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-proto/-/get-proto-1.0.1.tgz#150b3f2743869ef3e851ec0c49d15b1d14d00ee1"
+  integrity sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==
+  dependencies:
+    dunder-proto "^1.0.1"
+    es-object-atoms "^1.0.0"
 
 get-stream@^6.0.0:
   version "6.0.1"
@@ -5499,6 +5697,11 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
+gopd@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
+  integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
+
 graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.11, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
@@ -5550,6 +5753,11 @@ has-symbols@^1.0.2, has-symbols@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
   integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
+
+has-symbols@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.1.0.tgz#fc9c6a783a084951d0b971fe1018de813707a338"
+  integrity sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==
 
 has-tostringtag@^1.0.0, has-tostringtag@^1.0.2:
   version "1.0.2"
@@ -6036,6 +6244,11 @@ is-regex@^1.1.4:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
+is-retry-allowed@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-3.0.0.tgz#ea79389fd350d156823c491bee9c69f485b1445c"
+  integrity sha512-9xH0xvoggby+u0uGF7cZXdrutWiBiaFG8ZT4YFPXL8NzkyAwX3AKGLeFQLvzDpM430+nDFBZ1LHkie/8ocL06A==
+
 is-set@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.3.tgz#8ab209ea424608141372ded6e0cb200ef1d9d01d"
@@ -6467,6 +6680,11 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+math-intrinsics@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
+  integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -6549,7 +6767,7 @@ mime-db@1.52.0, "mime-db@>= 1.43.0 < 2":
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.27, mime-types@^2.1.31, mime-types@~2.1.17, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.12, mime-types@^2.1.27, mime-types@^2.1.31, mime-types@~2.1.17, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -7221,6 +7439,11 @@ proxy-addr@~2.0.7:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
 public-encrypt@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/public-encrypt/-/public-encrypt-4.0.3.tgz#4fcc9d77a07e48ba7527e7cbe0de33d0701331e0"
@@ -7526,6 +7749,14 @@ renderkid@^3.0.0:
     lodash "^4.17.21"
     strip-ansi "^6.0.1"
 
+require-addon@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/require-addon/-/require-addon-1.1.0.tgz#0a1ef0ba98b186a3aa304a1abda5208902e63e17"
+  integrity sha512-KbXAD5q2+v1GJnkzd8zzbOxchTkStSyJZ9QwoCq3QwEXAaIlG3wDYRZGzVD357jmwaGY7hr5VaoEAL0BkF0Kvg==
+  dependencies:
+    bare-addon-resolve "^1.3.0"
+    bare-url "^2.1.0"
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -7825,7 +8056,7 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-sha.js@^2.4.0, sha.js@^2.4.8:
+sha.js@^2.3.6, sha.js@^2.4.0, sha.js@^2.4.8:
   version "2.4.11"
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
   integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
@@ -7924,6 +8155,13 @@ sockjs@^0.3.24:
     faye-websocket "^0.11.3"
     uuid "^8.3.2"
     websocket-driver "^0.7.4"
+
+sodium-native@^4.3.3:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/sodium-native/-/sodium-native-4.3.3.tgz#fae4866b52366f5e6cc1b7ae8c8a71673d50c7df"
+  integrity sha512-OnxSlN3uyY8D0EsLHpmm2HOFmKddQVvEMmsakCrXUzSd8kjjbzL413t4ZNF3n0UxSwNgwTyUvkmZHTfuCeiYSw==
+  dependencies:
+    require-addon "^1.1.0"
 
 "source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.0.1, source-map-js@^1.2.1:
   version "1.2.1"
@@ -8268,6 +8506,11 @@ toidentifier@1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
+toml@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/toml/-/toml-3.0.0.tgz#342160f1af1904ec9d204d03a5d61222d762c5ee"
+  integrity sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==
+
 tree-dump@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/tree-dump/-/tree-dump-1.0.2.tgz#c460d5921caeb197bde71d0e9a7b479848c5b8ac"
@@ -8344,6 +8587,11 @@ turbo-stream@2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/turbo-stream/-/turbo-stream-2.4.0.tgz#1e4fca6725e90fa14ac4adb782f2d3759a5695f0"
   integrity sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==
+
+tweetnacl@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
+  integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -8485,6 +8733,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+urijs@^1.19.1:
+  version "1.19.11"
+  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.11.tgz#204b0d6b605ae80bea54bea39280cdb7c9f923cc"
+  integrity sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==
 
 url@^0.11.4:
   version "0.11.4"


### PR DESCRIPTION
### What

When a receiver's contract account wallet is selected:

- Balances of assets registered with SDP will have their balances fetched. This feature requires RPC integration; if the `RPC_URL` configuration is not set, then the balance will show "Unavailable".
- Recent wallet history is disabled

#### `RPC_URL` is set, balances are rendered

![Screenshot 2025-04-29 at 12 35 09 PM](https://github.com/user-attachments/assets/ded2ef3d-b062-4b42-b841-c9a80874bbf1)

#### `RPC_URL` is not set, balances are unavailable

![Screenshot 2025-04-29 at 12 35 28 PM](https://github.com/user-attachments/assets/35fed62a-1686-4194-b71a-5b87c678b7dd)

This change also filters out any assets with a 0 balance from the balances field for G-addresses. This is done for consistency with contract accounts. Contract accounts do not have a concept of a trustline, and therefore, we cannot distinguish a 0 balance from never receiving a balance.

### Why

The receiver page does not work when a contract account wallet is selected.

### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] Preview deployment works as expected
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Ready for production
