### PR TITLE
SDP-1736: Allow org level HTML customization of invite

### DIFF
--- a/src/apiQueries/useUpdateOrgHTMLEmailTemplate.ts
+++ b/src/apiQueries/useUpdateOrgHTMLEmailTemplate.ts
@@ -1,0 +1,35 @@
+import { useMutation } from "@tanstack/react-query";
+import { API_URL } from "constants/envVariables";
+import { fetchApi } from "helpers/fetchApi";
+import { AppError } from "types";
+
+export const useUpdateOrgHTMLEmailTemplate = () => {
+  const mutation = useMutation({
+    mutationFn: ({ template, subject }: { template: string; subject?: string }) => {
+      const formData = new FormData();
+
+      formData.append(
+        "data",
+        JSON.stringify({
+          receiver_registration_html_email_template: template,
+          receiver_registration_html_email_subject: subject || "",
+        }),
+      );
+
+      return fetchApi(
+        `${API_URL}/organization`,
+        {
+          method: "PATCH",
+          body: formData,
+        },
+        { omitContentType: true },
+      );
+    },
+  });
+
+  return {
+    ...mutation,
+    error: mutation.error as AppError,
+    data: mutation.data as { message: string },
+  };
+};

--- a/src/components/ReceiverInviteHTMLEmailTemplate/index.tsx
+++ b/src/components/ReceiverInviteHTMLEmailTemplate/index.tsx
@@ -36,6 +36,7 @@ export const ReceiverInviteHTMLEmailTemplate = () => {
       <p>You have a payment waiting for you from the {{.OrganizationName}}. Click <a href="{{.RegistrationLink}}">here</a> to register.</p>
     </body>
     </html>`.trim();
+  const PLACEHOLDER_SUBJECT = "You have a payment waiting for you from the {{.OrganizationName}}";
 
   const { organization } = useRedux("organization");
   const dispatch: AppDispatch = useDispatch();
@@ -49,8 +50,7 @@ export const ReceiverInviteHTMLEmailTemplate = () => {
     organization.data.receiverRegistrationHTMLEmailTemplate ?? PLACEHOLDER_TEMPLATE;
 
   const customSubject =
-    organization.data.receiverRegistrationHTMLEmailSubject ??
-    "You have a payment waiting for you from the {{.OrganizationName}}";
+    organization.data.receiverRegistrationHTMLEmailSubject ?? PLACEHOLDER_SUBJECT;
 
   const { isPending, data, isError, isSuccess, error, mutateAsync, reset } =
     useUpdateOrgHTMLEmailTemplate();
@@ -85,32 +85,27 @@ export const ReceiverInviteHTMLEmailTemplate = () => {
     }
   }, [dispatch, isSuccess]);
 
-  const handleOptionChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleOptionChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
     if (isPending) {
       return;
     }
 
     if (isError || isSuccess) {
-      reset();
+      await reset();
     }
 
-    // Adding little delay to make sure reset is done
-    const t = setTimeout(() => {
-      if (event.target.value === radioValue.DEFAULT) {
-        if (organization.data.receiverRegistrationHTMLEmailTemplate) {
-          mutateAsync({ template: "", subject: "" });
-        }
-
-        setIsEditTemplate(false);
-        setCustomTemplateInput("");
-        setCustomSubjectInput("");
-        setSelectedOption(radioValue.DEFAULT);
-      } else {
-        setSelectedOption(radioValue.CUSTOM);
+    if (event.target.value === radioValue.DEFAULT) {
+      if (organization.data.receiverRegistrationHTMLEmailTemplate) {
+        await mutateAsync({ template: "", subject: "" });
       }
 
-      clearTimeout(t);
-    }, 100);
+      setIsEditTemplate(false);
+      setCustomTemplateInput("");
+      setCustomSubjectInput("");
+      setSelectedOption(radioValue.DEFAULT);
+    } else {
+      setSelectedOption(radioValue.CUSTOM);
+    }
   };
 
   const handleSubmitTemplate = (event: React.FormEvent<HTMLFormElement>) => {
@@ -140,7 +135,7 @@ export const ReceiverInviteHTMLEmailTemplate = () => {
             id="html-email-subject-input"
             label="Email Subject"
             fieldSize="sm"
-            placeholder="🎉 Your payment from {{.OrganizationName}} is ready!"
+            placeholder={PLACEHOLDER_SUBJECT}
             value={customSubjectInput}
             onChange={(e) => setCustomSubjectInput(e.target.value)}
             disabled={isPending}
@@ -160,7 +155,7 @@ export const ReceiverInviteHTMLEmailTemplate = () => {
           />
 
           <div className="ReceiverInviteHTMLEmailTemplate__form__buttons">
-            <Button variant="secondary" size="xs" type="reset" isLoading={isPending}>
+            <Button variant="secondary" size="xs" type="reset" disabled={isPending}>
               Cancel
             </Button>
             <Button
@@ -202,9 +197,7 @@ export const ReceiverInviteHTMLEmailTemplate = () => {
             onClick={() => {
               setIsEditTemplate(true);
               setCustomTemplateInput(customTemplate);
-              setCustomSubjectInput(
-                customSubject || "🎉 Your payment from {{.OrganizationName}} is ready!",
-              );
+              setCustomSubjectInput(customSubject);
             }}
           >
             Edit template

--- a/src/components/ReceiverInviteHTMLEmailTemplate/index.tsx
+++ b/src/components/ReceiverInviteHTMLEmailTemplate/index.tsx
@@ -1,0 +1,300 @@
+import { Fragment, useEffect, useState } from "react";
+import {
+  Button,
+  Card,
+  Input,
+  Loader,
+  Notification,
+  RadioButton,
+  Textarea,
+} from "@stellar/design-system";
+import { useDispatch } from "react-redux";
+
+import { NotificationWithButtons } from "components/NotificationWithButtons";
+import { ErrorWithExtras } from "components/ErrorWithExtras";
+import { useUpdateOrgHTMLEmailTemplate } from "apiQueries/useUpdateOrgHTMLEmailTemplate";
+import { useRedux } from "hooks/useRedux";
+import { AppDispatch } from "store";
+import { getOrgInfoAction } from "store/ducks/organization";
+
+import "./styles.scss";
+
+export const ReceiverInviteHTMLEmailTemplate = () => {
+  enum radioValue {
+    DEFAULT = "default",
+    CUSTOM = "custom",
+  }
+
+  const PLACEHOLDER_TEMPLATE = `
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+      <meta charset="UTF-8">
+      {{EmailStyle}}
+    </head>
+    <body>
+      <p>You have a payment waiting for you from the {{.OrganizationName}}. Click <a href="{{.RegistrationLink}}">here</a> to register.</p>
+    </body>
+    </html>`.trim();
+
+  const { organization } = useRedux("organization");
+  const dispatch: AppDispatch = useDispatch();
+
+  const [selectedOption, setSelectedOption] = useState(radioValue.DEFAULT);
+  const [isEditTemplate, setIsEditTemplate] = useState(false);
+  const [customTemplateInput, setCustomTemplateInput] = useState("");
+  const [customSubjectInput, setCustomSubjectInput] = useState("");
+
+  const customTemplate =
+    organization.data.receiverRegistrationHTMLEmailTemplate ?? PLACEHOLDER_TEMPLATE;
+
+  const customSubject =
+    organization.data.receiverRegistrationHTMLEmailSubject ??
+    "You have a payment waiting for you from the {{.OrganizationName}}";
+
+  const { isPending, data, isError, isSuccess, error, mutateAsync, reset } =
+    useUpdateOrgHTMLEmailTemplate();
+
+  // Pre-select option when page loads
+  useEffect(() => {
+    setSelectedOption(
+      organization.data.receiverRegistrationHTMLEmailTemplate
+        ? radioValue.CUSTOM
+        : radioValue.DEFAULT,
+    );
+  }, [
+    organization.data.receiverRegistrationHTMLEmailTemplate,
+    radioValue.CUSTOM,
+    radioValue.DEFAULT,
+  ]);
+
+  // Clear error or success message when component unmounts
+  useEffect(() => {
+    return () => {
+      if (isError || isSuccess) {
+        reset();
+      }
+    };
+  }, [isError, isSuccess, reset]);
+
+  // On success, re-fetch org info and close edit form
+  useEffect(() => {
+    if (isSuccess) {
+      dispatch(getOrgInfoAction());
+      setIsEditTemplate(false);
+    }
+  }, [dispatch, isSuccess]);
+
+  const handleOptionChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (isPending) {
+      return;
+    }
+
+    if (isError || isSuccess) {
+      reset();
+    }
+
+    // Adding little delay to make sure reset is done
+    const t = setTimeout(() => {
+      if (event.target.value === radioValue.DEFAULT) {
+        if (organization.data.receiverRegistrationHTMLEmailTemplate) {
+          mutateAsync({ template: "", subject: "" });
+        }
+
+        setIsEditTemplate(false);
+        setCustomTemplateInput("");
+        setCustomSubjectInput("");
+        setSelectedOption(radioValue.DEFAULT);
+      } else {
+        setSelectedOption(radioValue.CUSTOM);
+      }
+
+      clearTimeout(t);
+    }, 100);
+  };
+
+  const handleSubmitTemplate = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (customTemplateInput.trim()) {
+      mutateAsync({
+        template: customTemplateInput.trim(),
+        subject: customSubjectInput.trim(),
+      });
+    }
+  };
+
+  const renderCustomTemplate = () => {
+    if (isEditTemplate) {
+      return (
+        <form
+          onSubmit={handleSubmitTemplate}
+          onReset={() => {
+            setIsEditTemplate(false);
+            setCustomTemplateInput("");
+            setCustomSubjectInput("");
+            reset();
+          }}
+          className="ReceiverInviteHTMLEmailTemplate__form"
+        >
+          <Input
+            id="html-email-subject-input"
+            label="Email Subject"
+            fieldSize="sm"
+            placeholder="🎉 Your payment from {{.OrganizationName}} is ready!"
+            value={customSubjectInput}
+            onChange={(e) => setCustomSubjectInput(e.target.value)}
+            disabled={isPending}
+            note="Available variables: {{.OrganizationName}}"
+          />
+
+          <Textarea
+            id="html-email-template-input"
+            label="HTML Email Template"
+            fieldSize="sm"
+            placeholder={PLACEHOLDER_TEMPLATE}
+            value={customTemplateInput}
+            onChange={(e) => setCustomTemplateInput(e.target.value)}
+            rows={15}
+            disabled={isPending}
+            note="Available variables: {{.OrganizationName}} and {{.RegistrationLink}}."
+          />
+
+          <div className="ReceiverInviteHTMLEmailTemplate__form__buttons">
+            <Button variant="secondary" size="xs" type="reset" isLoading={isPending}>
+              Cancel
+            </Button>
+            <Button
+              variant="primary"
+              size="xs"
+              type="submit"
+              isLoading={isPending}
+              disabled={!customTemplateInput.trim()}
+            >
+              Confirm
+            </Button>
+          </div>
+        </form>
+      );
+    }
+
+    return (
+      <div className="ReceiverInviteHTMLEmailTemplate__form">
+        <Input
+          id="html-email-subject-display"
+          label="Email Subject"
+          fieldSize="sm"
+          value={customSubject}
+          disabled
+        />
+
+        <Textarea
+          fieldSize="sm"
+          id="html-email-template-display"
+          label="HTML Email Template"
+          disabled
+          rows={15}
+          value={customTemplate}
+        />
+        <div className="ReceiverInviteHTMLEmailTemplate__form__buttons">
+          <Button
+            variant="primary"
+            size="xs"
+            onClick={() => {
+              setIsEditTemplate(true);
+              setCustomTemplateInput(customTemplate);
+              setCustomSubjectInput(
+                customSubject || "🎉 Your payment from {{.OrganizationName}} is ready!",
+              );
+            }}
+          >
+            Edit template
+          </Button>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <>
+      {isError ? (
+        <Notification variant="error" title="Error">
+          <ErrorWithExtras appError={error} />
+        </Notification>
+      ) : null}
+
+      {isSuccess ? (
+        <NotificationWithButtons
+          variant="success"
+          title="Success"
+          buttons={[
+            {
+              label: "Dismiss",
+              onClick: () => {
+                reset();
+              },
+            },
+          ]}
+        >
+          {data.message}
+        </NotificationWithButtons>
+      ) : null}
+
+      <Card>
+        <div className="CardStack__card ReceiverInviteHTMLEmailTemplate">
+          <div className="CardStack__title">Customize receiver wallet HTML email template</div>
+
+          <div className="Note">
+            Customize the HTML email template that will be sent to receivers when they need to
+            register their wallet to receive a payment. The HTML template is only used for email
+            invitations. SMS invitations will continue to use the plain text template.
+          </div>
+
+          <div className="ReceiverInviteHTMLEmailTemplate__options">
+            <RadioButton
+              id="html-email-template-standard"
+              name="html-email-template"
+              label={
+                <Fragment key="html-email-template-standard-label">
+                  {"Standard HTML email template"}{" "}
+                  {selectedOption === radioValue.DEFAULT && isPending ? (
+                    <Loader size="1.25rem" />
+                  ) : null}
+                </Fragment>
+              }
+              fieldSize="xs"
+              value={radioValue.DEFAULT}
+              checked={selectedOption === radioValue.DEFAULT}
+              onChange={handleOptionChange}
+              disabled={isPending}
+            />
+            <RadioButton
+              id="html-email-template-custom"
+              name="html-email-template"
+              label="Custom HTML email template"
+              fieldSize="xs"
+              value={radioValue.CUSTOM}
+              checked={selectedOption === radioValue.CUSTOM}
+              onChange={handleOptionChange}
+              disabled={isPending}
+            />
+          </div>
+
+          {selectedOption === radioValue.CUSTOM ? (
+            renderCustomTemplate()
+          ) : (
+            <div className="ReceiverInviteHTMLEmailTemplate__form">
+              <Textarea
+                fieldSize="sm"
+                id="html-email-template-standard"
+                disabled
+                rows={5}
+                value="Uses the default styled HTML email template with your organization branding."
+                note="Standard template with {{.OrganizationName}} and {{.RegistrationLink}} variables."
+              />
+            </div>
+          )}
+        </div>
+      </Card>
+    </>
+  );
+};

--- a/src/components/ReceiverInviteHTMLEmailTemplate/index.tsx
+++ b/src/components/ReceiverInviteHTMLEmailTemplate/index.tsx
@@ -85,10 +85,15 @@ export const ReceiverInviteHTMLEmailTemplate = () => {
     }
   }, [dispatch, isSuccess]);
 
+  const resetToDefault = () => {
+    setIsEditTemplate(false);
+    setCustomTemplateInput("");
+    setCustomSubjectInput("");
+    setSelectedOption(radioValue.DEFAULT);
+  };
+
   const handleOptionChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (isPending) {
-      return;
-    }
+    if (isPending) return;
 
     if (isError || isSuccess) {
       await reset();
@@ -96,25 +101,31 @@ export const ReceiverInviteHTMLEmailTemplate = () => {
 
     if (event.target.value === radioValue.DEFAULT) {
       if (organization.data.receiverRegistrationHTMLEmailTemplate) {
-        await mutateAsync({ template: "", subject: "" });
+        try {
+          await mutateAsync({ template: "", subject: "" });
+          resetToDefault();
+        } catch {
+          // Error handled by hook, don't update UI
+        }
+      } else {
+        resetToDefault();
       }
-
-      setIsEditTemplate(false);
-      setCustomTemplateInput("");
-      setCustomSubjectInput("");
-      setSelectedOption(radioValue.DEFAULT);
     } else {
       setSelectedOption(radioValue.CUSTOM);
     }
   };
 
-  const handleSubmitTemplate = (event: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmitTemplate = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (customTemplateInput.trim()) {
-      mutateAsync({
+    if (!customTemplateInput.trim()) return;
+
+    try {
+      await mutateAsync({
         template: customTemplateInput.trim(),
         subject: customSubjectInput.trim(),
       });
+    } catch {
+      // Error handled by hook, don't update UI
     }
   };
 

--- a/src/components/ReceiverInviteHTMLEmailTemplate/styles.scss
+++ b/src/components/ReceiverInviteHTMLEmailTemplate/styles.scss
@@ -1,0 +1,38 @@
+@use "../../styles-utils.scss" as *;
+
+.ReceiverInviteHTMLEmailTemplate {
+  &__options {
+    .RadioButton {
+      --RadioButton-font-size: #{pxToRem(14px)};
+    }
+
+    display: flex;
+    flex-direction: column;
+    gap: pxToRem(8px);
+  }
+
+  &__form {
+    display: flex;
+    flex-direction: column;
+    gap: pxToRem(16px);
+
+    .Textarea {
+      textarea {
+        font-family: var(--font-family-monospace);
+        font-size: pxToRem(13px);
+        line-height: 1.5;
+      }
+    }
+
+    &__buttons {
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      gap: pxToRem(8px);
+    }
+  }
+
+  .Note {
+    margin-top: 0;
+  }
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -3,6 +3,7 @@ import { Heading } from "@stellar/design-system";
 import { SectionHeader } from "components/SectionHeader";
 import { SettingsTeamMembers } from "components/SettingsTeamMembers";
 import { ReceiverInviteMessage } from "components/ReceiverInviteMessage";
+import { ReceiverInviteHTMLEmailTemplate } from "components/ReceiverInviteHTMLEmailTemplate";
 import { SettingsEnableShortLinking } from "components/SettingsEnableShortLinking";
 import { SettingsEnablePaymentCancellation } from "components/SettingsEnablePaymentCancellation";
 import { SettingsEnableReceiverInvitationRetry } from "components/SettingsEnableReceiverInvitationRetry";
@@ -36,6 +37,9 @@ export const Settings = () => {
 
         {/* Customize receiver wallet invite */}
         <ReceiverInviteMessage />
+
+        {/* Customize receiver wallet HTML email template */}
+        <ReceiverInviteHTMLEmailTemplate />
 
         {/* Team members */}
         <SettingsTeamMembers />

--- a/src/store/ducks/organization.ts
+++ b/src/store/ducks/organization.ts
@@ -18,53 +18,47 @@ export const getOrgInfoAction = createAsyncThunk<
   ApiOrgInfo,
   undefined,
   { rejectValue: RejectMessage; state: RootState }
->(
-  "organization/getOrgInfoAction",
-  async (_, { rejectWithValue, getState, dispatch }) => {
-    const { token } = getState().userAccount;
+>("organization/getOrgInfoAction", async (_, { rejectWithValue, getState, dispatch }) => {
+  const { token } = getState().userAccount;
 
-    try {
-      const orgInfo = await getOrgInfo(token);
-      refreshSessionToken(dispatch);
+  try {
+    const orgInfo = await getOrgInfo(token);
+    refreshSessionToken(dispatch);
 
-      return orgInfo;
-    } catch (error: unknown) {
-      const apiError = normalizeApiError(error as ApiError);
-      const errorString = apiError.message;
-      endSessionIfTokenInvalid(errorString, dispatch);
+    return orgInfo;
+  } catch (error: unknown) {
+    const apiError = normalizeApiError(error as ApiError);
+    const errorString = apiError.message;
+    endSessionIfTokenInvalid(errorString, dispatch);
 
-      return rejectWithValue({
-        errorString: `Error fetching organization info: ${errorString}`,
-      });
-    }
-  },
-);
+    return rejectWithValue({
+      errorString: `Error fetching organization info: ${errorString}`,
+    });
+  }
+});
 
 export const getOrgCircleInfoAction = createAsyncThunk<
   ApiOrgInfo,
   undefined,
   { rejectValue: RejectMessage; state: RootState }
->(
-  "organization/getOrgCircleInfoAction",
-  async (_, { rejectWithValue, getState, dispatch }) => {
-    const { token } = getState().userAccount;
+>("organization/getOrgCircleInfoAction", async (_, { rejectWithValue, getState, dispatch }) => {
+  const { token } = getState().userAccount;
 
-    try {
-      const orgInfo = await getOrgInfo(token);
-      refreshSessionToken(dispatch);
+  try {
+    const orgInfo = await getOrgInfo(token);
+    refreshSessionToken(dispatch);
 
-      return orgInfo;
-    } catch (error: unknown) {
-      const apiError = normalizeApiError(error as ApiError);
-      const errorString = apiError.message;
-      endSessionIfTokenInvalid(errorString, dispatch);
+    return orgInfo;
+  } catch (error: unknown) {
+    const apiError = normalizeApiError(error as ApiError);
+    const errorString = apiError.message;
+    endSessionIfTokenInvalid(errorString, dispatch);
 
-      return rejectWithValue({
-        errorString: `Error fetching organization info: ${errorString}`,
-      });
-    }
-  },
-);
+    return rejectWithValue({
+      errorString: `Error fetching organization info: ${errorString}`,
+    });
+  }
+});
 
 export const updateOrgInfoAction = createAsyncThunk<
   string,
@@ -104,23 +98,20 @@ export const getOrgLogoAction = createAsyncThunk<
   string,
   undefined,
   { rejectValue: RejectMessage; state: RootState }
->(
-  "organization/getOrgLogoAction",
-  async (_, { rejectWithValue, getState, dispatch }) => {
-    const { token } = getState().userAccount;
-    try {
-      return await getOrgLogo(token);
-    } catch (error: unknown) {
-      const apiError = normalizeApiError(error as ApiError);
-      const errorString = apiError.message;
-      endSessionIfTokenInvalid(errorString, dispatch);
+>("organization/getOrgLogoAction", async (_, { rejectWithValue, getState, dispatch }) => {
+  const { token } = getState().userAccount;
+  try {
+    return await getOrgLogo(token);
+  } catch (error: unknown) {
+    const apiError = normalizeApiError(error as ApiError);
+    const errorString = apiError.message;
+    endSessionIfTokenInvalid(errorString, dispatch);
 
-      return rejectWithValue({
-        errorString: `Error fetching organization logo: ${errorString}`,
-      });
-    }
-  },
-);
+    return rejectWithValue({
+      errorString: `Error fetching organization logo: ${errorString}`,
+    });
+  }
+});
 
 const initialState: OrganizationInitialState = {
   data: {
@@ -166,24 +157,23 @@ const organizationSlice = createSlice({
         ...state.data,
         name: action.payload.name,
         privacyPolicyLink: action.payload.privacy_policy_link,
-        distributionAccountPublicKey:
-          action.payload.distribution_account_public_key,
+        distributionAccountPublicKey: action.payload.distribution_account_public_key,
         timezoneUtcOffset: action.payload.timezone_utc_offset,
         isApprovalRequired: action.payload.is_approval_required,
-        receiverRegistrationMessageTemplate:
-          action.payload.receiver_registration_message_template,
+        receiverRegistrationMessageTemplate: action.payload.receiver_registration_message_template,
+        receiverRegistrationHTMLEmailTemplate:
+          action.payload.receiver_registration_html_email_template,
+        receiverRegistrationHTMLEmailSubject:
+          action.payload.receiver_registration_html_email_subject,
         isLinkShortenerEnabled: action.payload.is_link_shortener_enabled,
         isMemoTracingEnabled: action.payload.is_memo_tracing_enabled,
         baseUrl: action.payload.base_url,
         receiverInvitationResendInterval: Number(
           action.payload.receiver_invitation_resend_interval_days || 0,
         ),
-        paymentCancellationPeriodDays: Number(
-          action.payload.payment_cancellation_period_days || 0,
-        ),
+        paymentCancellationPeriodDays: Number(action.payload.payment_cancellation_period_days || 0),
         distributionAccount: {
-          circleWalletId:
-            action.payload.distribution_account?.circle_wallet_id || "",
+          circleWalletId: action.payload.distribution_account?.circle_wallet_id || "",
           status: action.payload.distribution_account?.status || "",
           type: action.payload.distribution_account?.type || "",
         },
@@ -205,8 +195,7 @@ const organizationSlice = createSlice({
       state.data = {
         ...state.data,
         distributionAccount: {
-          circleWalletId:
-            action.payload.distribution_account?.circle_wallet_id || "",
+          circleWalletId: action.payload.distribution_account?.circle_wallet_id || "",
           status: action.payload.distribution_account?.status || "",
           type: action.payload.distribution_account?.type || "",
         },
@@ -252,5 +241,4 @@ const organizationSlice = createSlice({
 
 export const organizationSelector = (state: RootState) => state.organization;
 export const { reducer } = organizationSlice;
-export const { clearUpdateMessageAction, clearErrorAction } =
-  organizationSlice.actions;
+export const { clearUpdateMessageAction, clearErrorAction } = organizationSlice.actions;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -71,6 +71,8 @@ export type OrganizationInitialState = {
     isApprovalRequired: boolean | undefined;
     receiverInvitationResendInterval: number;
     receiverRegistrationMessageTemplate?: string;
+    receiverRegistrationHTMLEmailTemplate?: string;
+    receiverRegistrationHTMLEmailSubject?: string;
     isLinkShortenerEnabled: boolean;
     isMemoTracingEnabled: boolean;
     baseUrl: string;
@@ -817,6 +819,8 @@ export type ApiOrgInfo = {
   is_approval_required: boolean;
   receiver_invitation_resend_interval_days: string;
   receiver_registration_message_template?: string;
+  receiver_registration_html_email_template?: string;
+  receiver_registration_html_email_subject?: string;
   is_link_shortener_enabled: boolean;
   is_memo_tracing_enabled: boolean;
   base_url: string;


### PR DESCRIPTION
### What

This adds a setting for custom HTML email disbursement invites.

<img width="735" height="780" alt="image" src="https://github.com/user-attachments/assets/91314eaa-9dd1-4f44-9ee4-ef4b60974656" />

### Why

We need to support custom HTML/CSS emails for the demo.

### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] Preview deployment works as expected
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Ready for production
