### PR TITLE
SDP-1843: Add initiator and approver roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-### Unreleased
+## Unreleased
 
+### Added
+- Add initiator and approver roles with separated disbursement operations to enforce role-based workflow controls.
+  [#346](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/346)
+
+### Changed
 - Improve CSV parsing robustness in `csvTotalAmount` helper by using PapaParse library to handle edge cases.  [#344](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/344)
 
 ## [4.0.1](https://github.com/stellar/stellar-disbursement-platform-frontend/releases/tag/4.0.0) ([diff](https://github.com/stellar/stellar-disbursement-platform-frontend/compare/4.0.0...4.0.1))

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -127,7 +127,15 @@ export const App = () => {
             <Route
               path={Routes.DISBURSEMENTS}
               element={
-                <PrivateRoute acceptedRoles={["owner", "financial_controller", "business"]}>
+                <PrivateRoute
+                  acceptedRoles={[
+                    "owner",
+                    "financial_controller",
+                    "business",
+                    "initiator",
+                    "approver",
+                  ]}
+                >
                   <InnerPage>
                     <Disbursements />
                   </InnerPage>
@@ -137,7 +145,15 @@ export const App = () => {
             <Route
               path={`${Routes.DISBURSEMENTS}/:id`}
               element={
-                <PrivateRoute acceptedRoles={["owner", "financial_controller", "business"]}>
+                <PrivateRoute
+                  acceptedRoles={[
+                    "owner",
+                    "financial_controller",
+                    "business",
+                    "initiator",
+                    "approver",
+                  ]}
+                >
                   <InnerPage>
                     <DisbursementDetails />
                   </InnerPage>
@@ -147,7 +163,7 @@ export const App = () => {
             <Route
               path={Routes.DISBURSEMENT_NEW}
               element={
-                <PrivateRoute acceptedRoles={["owner", "financial_controller"]}>
+                <PrivateRoute acceptedRoles={["owner", "financial_controller", "initiator"]}>
                   <InnerPage isNarrow>
                     <DisbursementsNew />
                   </InnerPage>
@@ -157,7 +173,9 @@ export const App = () => {
             <Route
               path={Routes.DISBURSEMENT_DRAFTS}
               element={
-                <PrivateRoute acceptedRoles={["owner", "financial_controller"]}>
+                <PrivateRoute
+                  acceptedRoles={["owner", "financial_controller", "initiator", "approver"]}
+                >
                   <InnerPage isNarrow>
                     <DisbursementsDrafts />
                   </InnerPage>
@@ -167,7 +185,9 @@ export const App = () => {
             <Route
               path={`${Routes.DISBURSEMENT_DRAFTS}/:id`}
               element={
-                <PrivateRoute acceptedRoles={["owner", "financial_controller"]}>
+                <PrivateRoute
+                  acceptedRoles={["owner", "financial_controller", "initiator", "approver"]}
+                >
                   <InnerPage isNarrow>
                     <DisbursementDraftDetails />
                   </InnerPage>
@@ -178,7 +198,15 @@ export const App = () => {
             <Route
               path={Routes.RECEIVERS}
               element={
-                <PrivateRoute acceptedRoles={["owner", "financial_controller", "business"]}>
+                <PrivateRoute
+                  acceptedRoles={[
+                    "owner",
+                    "financial_controller",
+                    "business",
+                    "initiator",
+                    "approver",
+                  ]}
+                >
                   <InnerPage>
                     <Receivers />
                   </InnerPage>
@@ -188,7 +216,15 @@ export const App = () => {
             <Route
               path={`${Routes.RECEIVERS}/:id`}
               element={
-                <PrivateRoute acceptedRoles={["owner", "financial_controller", "business"]}>
+                <PrivateRoute
+                  acceptedRoles={[
+                    "owner",
+                    "financial_controller",
+                    "business",
+                    "initiator",
+                    "approver",
+                  ]}
+                >
                   <InnerPage>
                     <ReceiverDetails />
                   </InnerPage>
@@ -209,7 +245,15 @@ export const App = () => {
             <Route
               path={`${Routes.PAYMENTS}/:id`}
               element={
-                <PrivateRoute acceptedRoles={["owner", "financial_controller", "business"]}>
+                <PrivateRoute
+                  acceptedRoles={[
+                    "owner",
+                    "financial_controller",
+                    "business",
+                    "initiator",
+                    "approver",
+                  ]}
+                >
                   <InnerPage>
                     <PaymentDetails />
                   </InnerPage>
@@ -219,7 +263,15 @@ export const App = () => {
             <Route
               path={Routes.PAYMENTS}
               element={
-                <PrivateRoute acceptedRoles={["owner", "financial_controller", "business"]}>
+                <PrivateRoute
+                  acceptedRoles={[
+                    "owner",
+                    "financial_controller",
+                    "business",
+                    "initiator",
+                    "approver",
+                  ]}
+                >
                   <InnerPage>
                     <Payments />
                   </InnerPage>

--- a/src/components/DisbursementButtons/index.tsx
+++ b/src/components/DisbursementButtons/index.tsx
@@ -1,9 +1,9 @@
 import { Button, Icon } from "@stellar/design-system";
 import { useNavigate } from "react-router-dom";
 import { Routes } from "@/constants/settings";
+import { ShowForRoles } from "@/components/ShowForRoles";
 import { DisbursementDraftAction, DisbursementStep } from "@/types";
 import "./styles.scss";
-import { ShowForRoles } from "@/components/ShowForRoles";
 
 interface DisbursementButtonsPros {
   variant: DisbursementStep;

--- a/src/components/DisbursementButtons/index.tsx
+++ b/src/components/DisbursementButtons/index.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { Routes } from "@/constants/settings";
 import { DisbursementDraftAction, DisbursementStep } from "@/types";
 import "./styles.scss";
+import { ShowForRoles } from "@/components/ShowForRoles";
 
 interface DisbursementButtonsPros {
   variant: DisbursementStep;
@@ -18,6 +19,7 @@ interface DisbursementButtonsPros {
   isDraftPending?: boolean;
   actionType?: DisbursementDraftAction;
   tooltip?: string;
+  isCsvFileUpdated?: boolean;
 }
 
 export const DisbursementButtons = ({
@@ -34,6 +36,7 @@ export const DisbursementButtons = ({
   isDraftPending,
   actionType,
   tooltip,
+  isCsvFileUpdated,
 }: DisbursementButtonsPros) => {
   const navigate = useNavigate();
 
@@ -155,27 +158,31 @@ export const DisbursementButtons = ({
           </Button>
 
           <div className="DisbursementButtons--continue">
-            <Button
-              variant="tertiary"
-              size="md"
-              onClick={handleSaveDraft}
-              isLoading={isSavePending}
-              disabled={isDraftDisabled || isSubmitPending}
-            >
-              Save as a draft
-            </Button>
-            <Button
-              variant="primary"
-              size="md"
-              icon={<Icon.CheckCircle />}
-              iconPosition="right"
-              type="submit"
-              disabled={isSubmitDisabled || isSavePending}
-              isLoading={isSubmitPending}
-              {...(tooltip ? { title: tooltip } : {})}
-            >
-              Confirm disbursement
-            </Button>
+            <ShowForRoles acceptedRoles={["owner", "financial_controller", "initiator"]}>
+              <Button
+                variant="tertiary"
+                size="md"
+                onClick={handleSaveDraft}
+                isLoading={isSavePending}
+                disabled={isDraftDisabled || isSubmitPending}
+              >
+                Save as a draft
+              </Button>
+            </ShowForRoles>
+            <ShowForRoles acceptedRoles={["owner", "financial_controller", "approver"]}>
+              <Button
+                variant="primary"
+                size="md"
+                icon={<Icon.CheckCircle />}
+                iconPosition="right"
+                type="submit"
+                disabled={isSubmitDisabled || isSavePending || isCsvFileUpdated}
+                isLoading={isSubmitPending}
+                {...(tooltip ? { title: tooltip } : {})}
+              >
+                Confirm disbursement
+              </Button>
+            </ShowForRoles>
           </div>
         </>
       );

--- a/src/components/DisbursementInstructions/index.tsx
+++ b/src/components/DisbursementInstructions/index.tsx
@@ -109,7 +109,7 @@ export const DisbursementInstructions: React.FC<DisbursementInstructionsProps> =
 
         <div className="DisbursementInstructions__buttons">
           <Button
-            size="md"
+            size="sm"
             variant="tertiary"
             onClick={handleDownloadTemplate}
             disabled={!csvTemplateName}

--- a/src/components/NewDisbursementButton.tsx
+++ b/src/components/NewDisbursementButton.tsx
@@ -16,7 +16,7 @@ export const NewDisbursementButton = () => {
   const disableMessage = inactiveCircleAccount ? "Circle Account is not active" : "";
 
   return (
-    <ShowForRoles acceptedRoles={["owner", "financial_controller"]}>
+    <ShowForRoles acceptedRoles={["owner", "financial_controller", "initiator"]}>
       <Button
         variant="primary"
         size="md"

--- a/src/constants/settings.ts
+++ b/src/constants/settings.ts
@@ -45,6 +45,8 @@ export const USER_ROLES_ARRAY: UserRole[] = [
   "financial_controller",
   "developer",
   "business",
+  "initiator",
+  "approver",
 ];
 
 export const TIME_ZONES = [

--- a/src/helpers/userRoleText.ts
+++ b/src/helpers/userRoleText.ts
@@ -10,6 +10,10 @@ export const userRoleText = (role?: UserRole | null) => {
       return "Developer";
     case "financial_controller":
       return "Financial controller";
+    case "initiator":
+      return "Initiator";
+    case "approver":
+      return "Approver";
     default:
       return "";
   }

--- a/src/pages/Disbursements.tsx
+++ b/src/pages/Disbursements.tsx
@@ -177,7 +177,9 @@ export const Disbursements = () => {
             </Heading>
           </SectionHeader.Content>
           <SectionHeader.Content align="right">
-            <ShowForRoles acceptedRoles={["owner", "financial_controller"]}>
+            <ShowForRoles
+              acceptedRoles={["owner", "financial_controller", "initiator", "approver"]}
+            >
               <Button
                 variant="tertiary"
                 size="md"

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -70,7 +70,9 @@ export const Home = () => {
         <DashboardAnalytics />
       </div>
 
-      <ShowForRoles acceptedRoles={["business", "financial_controller", "owner"]}>
+      <ShowForRoles
+        acceptedRoles={["business", "financial_controller", "owner", "initiator", "approver"]}
+      >
         <SectionHeader>
           <SectionHeader.Row>
             <SectionHeader.Content>
@@ -82,7 +84,7 @@ export const Home = () => {
               <Button size="md" variant="tertiary" onClick={goToDisbursements}>
                 View all
               </Button>
-              <ShowForRoles acceptedRoles={["owner", "financial_controller"]}>
+              <ShowForRoles acceptedRoles={["owner", "financial_controller", "initiator"]}>
                 <NewDisbursementButton />
               </ShowForRoles>
             </SectionHeader.Content>

--- a/src/pages/Payments.tsx
+++ b/src/pages/Payments.tsx
@@ -11,6 +11,7 @@ import { Pagination } from "@/components/Pagination";
 import { PaymentsTable } from "@/components/PaymentsTable";
 import { SearchInput } from "@/components/SearchInput";
 import { SectionHeader } from "@/components/SectionHeader";
+import { ShowForRoles } from "@/components/ShowForRoles";
 import { DirectPaymentCreateModal } from "@/components/DirectPaymentCreateModal/DirectPaymentCreateModal";
 import { ErrorWithExtras } from "@/components/ErrorWithExtras";
 
@@ -138,14 +139,16 @@ export const Payments = () => {
           </SectionHeader.Content>
 
           <SectionHeader.Content align="right">
-            <Button
-              variant="primary"
-              size="md"
-              onClick={handleCreateDirectPayment}
-              disabled={isLoading || isFetching}
-            >
-              New Direct Payment
-            </Button>
+            <ShowForRoles acceptedRoles={["owner", "financial_controller"]}>
+              <Button
+                variant="primary"
+                size="md"
+                onClick={handleCreateDirectPayment}
+                disabled={isLoading || isFetching}
+              >
+                New Direct Payment
+              </Button>
+            </ShowForRoles>
           </SectionHeader.Content>
         </SectionHeader.Row>
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -176,7 +176,13 @@ export type JwtUser = {
   roles: UserRole[] | null;
 };
 
-export type UserRole = "owner" | "financial_controller" | "developer" | "business";
+export type UserRole =
+  | "owner"
+  | "financial_controller"
+  | "developer"
+  | "business"
+  | "initiator"
+  | "approver";
 
 export type NewUser = {
   first_name: string;


### PR DESCRIPTION
### What

- Implemented initiator and approver roles with separated disbursement operations. Initiators can create and save drafts but cannot confirm disbursements, while approvers can confirm clean drafts but cannot save changes. 
- Added form state tracking to disable confirmation when drafts have unsaved modifications. This allows to separate saving the disbursement from confirming it to be able to assign different roles to different operations. 

### Why

- The platform needed role separation for compliance and workflow control, where different users handle disbursement creation vs approval. 

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] Preview deployment works as expected
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Ready for production
