### PR TITLE
SDP-1879: Add ignore memo tracing note for embedded wallets

### DIFF
--- a/src/components/SettingsEnableMemoTracking.tsx
+++ b/src/components/SettingsEnableMemoTracking.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 import { useDispatch } from "react-redux";
 
 import { useUpdateOrgMemoTrackingEnabled } from "@/apiQueries/useUpdateOrgMemoTrackingEnabled";
+import { Box } from "@/components/Box";
 import { ErrorWithExtras } from "@/components/ErrorWithExtras";
 import { useRedux } from "@/hooks/useRedux";
 import { AppDispatch } from "@/store";
@@ -44,16 +45,17 @@ export const SettingsEnableMemoTracking = () => {
               />
             </div>
           </div>
-          <div className="Note">
+          <Box gap="xs" addlClassName="Note">
             <span>
               When enabled, payments will include an organization-specific memo if the receiver's
               wallet doesn't have an associated memo. This memo is derived from your server URL and
               will update if the URL changes (e.g. <code>sdp-100680ad546c</code>).
             </span>
             <span className="Note__emphasis">
-              Note: Memo tracing is ignored for Embedded Wallets due to memo fields not supported.
+              Note: Memo tracing is automatically disabled for Embedded Wallets due to memos not
+              being supported.
             </span>
-          </div>
+          </Box>
         </div>
       </div>
     );

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -101,7 +101,6 @@ body {
 
 .Note__emphasis {
   display: block;
-  margin-top: pxToRem(6px);
   font-size: pxToRem(12px);
   line-height: pxToRem(18px);
   font-weight: 500;


### PR DESCRIPTION
### What

Add a note to memo tracing setting on frontend

<img width="721" height="225" alt="Screenshot 2025-10-11 at 9 40 19 AM" src="https://github.com/user-attachments/assets/34fd99f5-bac9-4e4b-a8d0-a213d202718b" />


### Why

 Memo tracing is ignored for embedded wallets.
 Wording confirmed with Tori
 
### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] Preview deployment works as expected
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Ready for production
