### PR TITLE
Fix wallet history amount display overflow

### DIFF
--- a/src/components/WalletHistory.tsx
+++ b/src/components/WalletHistory.tsx
@@ -28,7 +28,7 @@ export const WalletHistory = ({ stellarAddress }: WalletHistoryProps) => {
 
   return (
     <Card noPadding>
-      <Table isScrollable>
+      <Table isScrollable={true}>
         <Table.Header>
           <Table.HeaderCell>Operation ID</Table.HeaderCell>
           <Table.HeaderCell>Date/time</Table.HeaderCell>
@@ -58,7 +58,7 @@ export const WalletHistory = ({ stellarAddress }: WalletHistoryProps) => {
                   {p.memo ? <span className="Table-v2__cell--secondary">{p.memo}</span> : null}
                 </Table.BodyCell>
                 <Table.BodyCell textAlign="right">
-                  <span style={{ display: "inline-flex" }}>
+                  <span className="WalletHistory__amount">
                     {p.operationKind === "send" ? "-" : "+"}
                     <AssetAmount amount={p.amount} assetCode={p.assetCode} fallback="-" />
                   </span>

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -457,6 +457,10 @@ body {
 }
 
 // Wallets
+.WalletHistory__amount {
+  display: inline-flex;
+}
+
 .WalletBalances {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## What
- Added `isScrollable` prop to the wallet history table
- Wrapped the +/- sign and amount in an inline-flex container

## Why
Large amounts (e.g., 1,000,000,000.00) caused the +/- sign to wrap to a separate line and overflow outside the table boundary. These changes keep the sign attached to the amount and enable horizontal scrolling for long values.

*Before* 
<img width="720" height="385" alt="image" src="https://github.com/user-attachments/assets/8cc8544f-0592-455d-b469-f30998a0eb29" />
*After*
<img width="588" height="368" alt="image" src="https://github.com/user-attachments/assets/0d245b2e-72d3-4752-b49c-44dfcdd34d47" />


### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] Preview deployment works as expected
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Ready for production
