### PR TITLE
Fix SEP-45 in multitenant mode

### DIFF
--- a/src/helpers/sep45Authentication/authenticateWithSep45.ts
+++ b/src/helpers/sep45Authentication/authenticateWithSep45.ts
@@ -15,18 +15,17 @@ export const authenticateWithSep45 = async (
   credentialId: string,
 ): Promise<string> => {
   const tomlValues = await getRequiredTomlInfo(SEP45_REQUIRED_TOML_FIELDS);
-  const homeDomain = window.location.host;
   const webAuthDomain = new URL(tomlValues.WEB_AUTH_FOR_CONTRACTS_ENDPOINT).host;
 
   const authEntries = await start({
     authEndpoint: tomlValues.WEB_AUTH_FOR_CONTRACTS_ENDPOINT,
     contractAddress,
-    homeDomain,
+    homeDomain: webAuthDomain,
   });
 
   const expectedArgs = {
     account: contractAddress,
-    home_domain: homeDomain,
+    home_domain: webAuthDomain,
     web_auth_domain: webAuthDomain,
     web_auth_domain_account: tomlValues.SIGNING_KEY,
   } as const;


### PR DESCRIPTION
### What

This fixes the SEP-45 auth flow by setting the home domain to the web auth domain. This requires the backend to serve the API at `stellar.local:8000` instead of `localhost:8000`.

### Why

Allows for SEP-45 to work in a multitenant flow.

### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] Preview deployment works as expected
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Ready for production
