### PR TITLE
SDP-1954: Add SAC transfer support to Wallet History component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Improve Wallet History: filter spam/dust transactions (<0.001), show last 10 payments, add Stellar Expert link, add info tooltip, and increase asset amount decimal precision from 2 to 3 digits. [#414](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/414)
+- Improve Wallet History Component functionality:
+   - Filter spam/dust transactions (<0.001), show last 10 payments, add Stellar Expert link, add info tooltip, and increase asset amount decimal precision from 2 to 3 digits. [#414](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/414)
+   - Add support for contract accounts operations in the Wallet History component. [#419](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/419)
 
 ### Security and Dependencies
 

--- a/src/apiQueries/useStellarAccountPayments.ts
+++ b/src/apiQueries/useStellarAccountPayments.ts
@@ -4,13 +4,92 @@ import { getStellarTransaction } from "@/api/getStellarTransaction";
 import { HORIZON_URL } from "@/constants/envVariables";
 import { fetchStellarApi } from "@/helpers/fetchStellarApi";
 import { shortenAccountKey } from "@/helpers/shortenAccountKey";
-import { ApiStellarOperationRecord, AppError, ReceiverWalletPayment } from "@/types";
+import {
+  ApiStellarOperationInvokeHostFunction,
+  ApiStellarOperationPayment,
+  ApiStellarOperationRecord,
+  AppError,
+  ReceiverWalletPayment,
+} from "@/types";
 
 /** Minimum amount to filter out dust/spam transactions */
 const MIN_PAYMENT_AMOUNT = 0.001;
 
 /** Default number of payments to return */
 export const DEFAULT_PAYMENT_LIMIT = 10;
+
+/**
+ * Normalized payment data extracted from different Horizon operation types.
+ * This abstracts away the differences between classic payments and SAC transfers.
+ */
+interface NormalizedPaymentData {
+  amount: string;
+  from: string;
+  to: string;
+  assetCode: string;
+  assetIssuer: string;
+}
+
+/** Type guard for SAC transfers */
+const isInvokeHostFunction = (
+  record: ApiStellarOperationRecord,
+): record is ApiStellarOperationInvokeHostFunction => {
+  return record.type === "invoke_host_function";
+};
+
+/**
+ * Extracts payment data from a Horizon operation record.
+ * Handles both classic payments and SAC transfers (invoke_host_function).
+ * Returns null if the record doesn't contain valid payment data.
+ */
+const extractPaymentData = (
+  record: ApiStellarOperationRecord,
+  walletAddress?: string,
+): NormalizedPaymentData | null => {
+  // SAC transfers use invoke_host_function with asset_balance_changes
+  if (isInvokeHostFunction(record)) {
+    const balanceChanges = record.asset_balance_changes;
+
+    if (!balanceChanges || balanceChanges.length === 0) {
+      return null;
+    }
+
+    // If walletAddress is provided, try to find the change that involves the user.
+    // Otherwise, default to the first change.
+    let change = balanceChanges[0];
+    if (walletAddress) {
+      const userChange = balanceChanges.find(
+        (c) => c.from === walletAddress || c.to === walletAddress,
+      );
+      if (userChange) {
+        change = userChange;
+      }
+    }
+
+    return {
+      amount: change.amount,
+      from: change.from,
+      to: change.to,
+      assetCode: change.asset_type === "native" ? "XLM" : change.asset_code || "",
+      assetIssuer: change.asset_type === "native" ? "" : change.asset_issuer || "",
+    };
+  }
+
+  // Classic payments (payment, path_payment_strict_send, path_payment_strict_receive)
+  // We check for the existence of required fields to ensure it's a valid payment operation
+  const classicOp = record as ApiStellarOperationPayment;
+  if (!classicOp.amount || !classicOp.from || !classicOp.to) {
+    return null;
+  }
+
+  return {
+    amount: classicOp.amount,
+    from: classicOp.from,
+    to: classicOp.to,
+    assetCode: classicOp.asset_code || "",
+    assetIssuer: classicOp.asset_issuer || "",
+  };
+};
 
 export const useStellarAccountPayments = (
   stellarAddress: string | undefined,
@@ -37,20 +116,33 @@ export const useStellarAccountPayments = (
 
       const { records } = response._embedded;
 
-      // Filter out dust/spam transactions below minimum amount
-      const filteredRecords = records.filter(
-        (r: ApiStellarOperationRecord) => parseFloat(r.amount) >= MIN_PAYMENT_AMOUNT,
+      const payments = await Promise.all(
+        records
+          // 1. Extract data first (Map)
+          .map((record: ApiStellarOperationRecord) => ({
+            record,
+            paymentData: extractPaymentData(record, stellarAddress),
+          }))
+          // 2. Filter invalid or dust payments
+          .filter(
+            (item: {
+              record: ApiStellarOperationRecord;
+              paymentData: NormalizedPaymentData | null;
+            }) => item.paymentData && parseFloat(item.paymentData.amount) >= MIN_PAYMENT_AMOUNT,
+          )
+          // 3. Limit to the requested number
+          .slice(0, limit)
+          // 4. Format final output (Async Map)
+          .map(
+            ({
+              record,
+              paymentData,
+            }: {
+              record: ApiStellarOperationRecord;
+              paymentData: NormalizedPaymentData | null;
+            }) => formatWalletPayment(record, paymentData!, stellarAddress),
+          ),
       );
-
-      // Take only the requested number of payments
-      const limitedRecords = filteredRecords.slice(0, limit);
-
-      const payments = [];
-
-      for (const record of limitedRecords) {
-        const payment = await formatWalletPayment(record, stellarAddress);
-        payments.push(payment);
-      }
 
       return payments;
     },
@@ -61,23 +153,24 @@ export const useStellarAccountPayments = (
 };
 
 const formatWalletPayment = async (
-  payment: ApiStellarOperationRecord,
+  record: ApiStellarOperationRecord,
+  paymentData: NormalizedPaymentData,
   walletAddress: string,
 ): Promise<ReceiverWalletPayment> => {
-  const isSend = payment.from === walletAddress;
+  const isSend = paymentData.from === walletAddress;
 
   // Getting transaction details to get the memo
-  const transaction = await getStellarTransaction(payment.transaction_hash);
+  const transaction = await getStellarTransaction(record.transaction_hash);
 
   return {
-    id: payment.id.toString(),
-    amount: payment.amount,
-    paymentAddress: isSend ? payment.to : payment.from,
-    createdAt: payment.created_at,
-    assetCode: payment.asset_code,
-    assetIssuer: payment.asset_issuer,
+    id: record.id.toString(),
+    amount: paymentData.amount,
+    paymentAddress: isSend ? paymentData.to : paymentData.from,
+    createdAt: record.created_at,
+    assetCode: paymentData.assetCode,
+    assetIssuer: paymentData.assetIssuer,
     operationKind: isSend ? "send" : "receive",
-    transactionHash: payment.transaction_hash,
+    transactionHash: record.transaction_hash,
     memo: transaction.memo || "",
   };
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -861,12 +861,14 @@ export type ApiNewUser = {
 export type ApiStellarOperationRecord =
   | ApiStellarOperationPayment
   | ApiStellarOperationPathPaymentStrictReceive
-  | ApiStellarOperationPathPaymentStrictSend;
+  | ApiStellarOperationPathPaymentStrictSend
+  | ApiStellarOperationInvokeHostFunction;
 
 export type ApiStellarPaymentType =
   | "payment"
   | "path_payment_strict_send"
-  | "path_payment_strict_receive";
+  | "path_payment_strict_receive"
+  | "invoke_host_function";
 
 export interface ApiStellarOperationBase {
   id: number;
@@ -907,6 +909,18 @@ export interface ApiStellarOperationPathPaymentStrictReceive extends ApiStellarO
 
 export interface ApiStellarOperationPathPaymentStrictSend extends ApiStellarOperationPathPayment {
   destination_min: string;
+}
+
+export interface ApiStellarOperationInvokeHostFunction extends ApiStellarOperationBase {
+  asset_balance_changes?: {
+    asset_type: string;
+    asset_code?: string;
+    asset_issuer?: string;
+    type: string;
+    from: string;
+    to: string;
+    amount: string;
+  }[];
 }
 
 export type ApiStellarTransaction = {


### PR DESCRIPTION
### What
Add SAC transfer support to Wallet History component.


### Why
Surface payments of type `invoke_host_function`. 

***Before:*** 
<img width="1496" height="183" alt="Screenshot 2025-12-18 at 3 03 08 PM" src="https://github.com/user-attachments/assets/da1dd3bc-23bb-4ba3-9ec8-376072eb7e83" />

***After:***
<img width="1434" height="343" alt="Screenshot 2025-12-18 at 3 03 32 PM" src="https://github.com/user-attachments/assets/201dfa89-21ad-4be5-a2b7-f8f02df96cd5" />

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] Preview deployment works as expected
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Ready for production
