### PR TITLE
Fix: Render wallet home page when receiver is not verified

### DIFF
--- a/src/pages/EmbeddedWalletHome.tsx
+++ b/src/pages/EmbeddedWalletHome.tsx
@@ -105,20 +105,19 @@ export const EmbeddedWalletHome = () => {
   );
 
   const receiverContact = walletAccount.receiverContact;
-  if (!receiverContact) {
-    return null;
-  }
 
   return (
     <EmbeddedWalletLayout
       organizationName={organizationName}
       organizationLogo={organization?.data?.logo}
       headerRight={
-        <EmbeddedWalletProfileDropdown
-          contact={receiverContact}
-          onOpenProfile={() => setIsProfileModalOpen(true)}
-          onLogout={handleLogout}
-        />
+        receiverContact ? (
+          <EmbeddedWalletProfileDropdown
+            contact={receiverContact}
+            onOpenProfile={() => setIsProfileModalOpen(true)}
+            onLogout={handleLogout}
+          />
+        ) : null
       }
     >
       <Box gap="md">
@@ -184,12 +183,14 @@ export const EmbeddedWalletHome = () => {
         contentAlign="left"
       />
 
-      <EmbeddedWalletProfileModal
-        isOpen={isProfileModalOpen}
-        onClose={() => setIsProfileModalOpen(false)}
-        contact={receiverContact}
-        contractAddress={contractAddress}
-      />
+      {receiverContact ? (
+        <EmbeddedWalletProfileModal
+          isOpen={isProfileModalOpen}
+          onClose={() => setIsProfileModalOpen(false)}
+          contact={receiverContact}
+          contractAddress={contractAddress}
+        />
+      ) : null}
     </EmbeddedWalletLayout>
   );
 };


### PR DESCRIPTION
### What

The fixes the home page when the user's verification is pending so that the home page is still rendered, but the profile is not showing.

### Why

Currently, if the user is not verified, the page is blank.

### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] Preview deployment works as expected
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Ready for production
