### PR TITLE
Fix: Logout user when wallet JWT expires

### DIFF
--- a/src/api/embeddedWallet.ts
+++ b/src/api/embeddedWallet.ts
@@ -1,4 +1,4 @@
-import { handleApiResponse } from "@/api/handleApiResponse";
+import { handleWalletApiResponse } from "@/api/handleWalletApiResponse";
 import { API_URL } from "@/constants/envVariables";
 import { getSdpTenantName } from "@/helpers/getSdpTenantName";
 import type { EmbeddedWalletProfileResponse } from "@/types";
@@ -28,7 +28,7 @@ export const createEmbeddedWallet = async (
     body: JSON.stringify(request),
   });
 
-  return handleApiResponse(response);
+  return handleWalletApiResponse<WalletResponse>(response);
 };
 
 export const getWalletStatus = async (credentialId: string): Promise<WalletResponse> => {
@@ -40,7 +40,7 @@ export const getWalletStatus = async (credentialId: string): Promise<WalletRespo
     },
   });
 
-  return handleApiResponse(response);
+  return handleWalletApiResponse<WalletResponse>(response);
 };
 
 export const pollWalletStatus = async (
@@ -77,5 +77,5 @@ export const getEmbeddedWalletProfile = async (
     },
   });
 
-  return handleApiResponse(response);
+  return handleWalletApiResponse<EmbeddedWalletProfileResponse>(response);
 };

--- a/src/api/handleWalletApiResponse.ts
+++ b/src/api/handleWalletApiResponse.ts
@@ -1,0 +1,18 @@
+import { WALLET_SESSION_EXPIRED } from "@/constants/settings";
+import type { ApiError } from "@/types";
+
+export const handleWalletApiResponse = async <ResponseType>(
+  response: Response,
+): Promise<ResponseType> => {
+  if (response.status === 401) {
+    throw WALLET_SESSION_EXPIRED;
+  }
+
+  const responseJson = await response.json();
+
+  if (responseJson.error) {
+    throw responseJson as ApiError;
+  }
+
+  return responseJson as ResponseType;
+};

--- a/src/api/passkeyRefresh.ts
+++ b/src/api/passkeyRefresh.ts
@@ -1,4 +1,4 @@
-import { handleApiResponse } from "@/api/handleApiResponse";
+import { handleWalletApiResponse } from "@/api/handleWalletApiResponse";
 import { API_URL } from "@/constants/envVariables";
 import { getSdpTenantName } from "@/helpers/getSdpTenantName";
 
@@ -20,5 +20,5 @@ export const refreshPasskeyToken = async (token: string): Promise<PasskeyRefresh
     body: JSON.stringify({ token }),
   });
 
-  return handleApiResponse(response);
+  return handleWalletApiResponse<PasskeyRefreshResponse>(response);
 };

--- a/src/components/WalletSession.tsx
+++ b/src/components/WalletSession.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useDispatch } from "react-redux";
 
-import { SESSION_EXPIRED_EVENT } from "@/constants/settings";
+import { WALLET_SESSION_EXPIRED_EVENT } from "@/constants/settings";
 import { localStorageWalletSessionToken } from "@/helpers/localStorageWalletSessionToken";
 import { parseJwt } from "@/helpers/parseJwt";
 import { useRedux } from "@/hooks/useRedux";
@@ -59,12 +59,13 @@ export const WalletSession = () => {
   useEffect(() => {
     const onSessionExpired = () => {
       dispatch(walletSessionExpiredAction());
+      localStorageWalletSessionToken.remove();
     };
 
-    document.addEventListener(SESSION_EXPIRED_EVENT, onSessionExpired);
+    document.addEventListener(WALLET_SESSION_EXPIRED_EVENT, onSessionExpired);
 
     return () => {
-      document.removeEventListener(SESSION_EXPIRED_EVENT, onSessionExpired);
+      document.removeEventListener(WALLET_SESSION_EXPIRED_EVENT, onSessionExpired);
     };
   }, [dispatch]);
 

--- a/src/constants/settings.ts
+++ b/src/constants/settings.ts
@@ -7,6 +7,7 @@ export const RESET_STORE_ACTION_TYPE = "RESET";
 export const GENERIC_ERROR_MESSAGE = "Something went wrong, please try again";
 export const SESSION_EXPIRED = "SESSION EXPIRED";
 export const SESSION_EXPIRED_EVENT = "sdp_session_expired_event";
+export const WALLET_SESSION_EXPIRED_EVENT = "sdp_wallet_session_expired_event";
 export const LOCAL_STORAGE_SESSION_TOKEN = "sdp_session";
 export const LOCAL_STORAGE_WALLET_SESSION_TOKEN = "sdp_wallet_session";
 export const LOCAL_STORAGE_DEVICE_ID = "sdp_deviceID";

--- a/src/constants/settings.ts
+++ b/src/constants/settings.ts
@@ -7,6 +7,7 @@ export const RESET_STORE_ACTION_TYPE = "RESET";
 export const GENERIC_ERROR_MESSAGE = "Something went wrong, please try again";
 export const SESSION_EXPIRED = "SESSION EXPIRED";
 export const SESSION_EXPIRED_EVENT = "sdp_session_expired_event";
+export const WALLET_SESSION_EXPIRED = "WALLET SESSION EXPIRED";
 export const WALLET_SESSION_EXPIRED_EVENT = "sdp_wallet_session_expired_event";
 export const LOCAL_STORAGE_SESSION_TOKEN = "sdp_session";
 export const LOCAL_STORAGE_WALLET_SESSION_TOKEN = "sdp_wallet_session";

--- a/src/helpers/fetchWalletApi.ts
+++ b/src/helpers/fetchWalletApi.ts
@@ -1,7 +1,7 @@
 import { differenceInMinutes, fromUnixTime } from "date-fns";
 
-import { handleApiResponse } from "@/api/handleApiResponse";
-import { SESSION_EXPIRED, WALLET_SESSION_EXPIRED_EVENT } from "@/constants/settings";
+import { handleWalletApiResponse } from "@/api/handleWalletApiResponse";
+import { WALLET_SESSION_EXPIRED, WALLET_SESSION_EXPIRED_EVENT } from "@/constants/settings";
 import { getSdpTenantName } from "@/helpers/getSdpTenantName";
 import { localStorageWalletSessionToken } from "@/helpers/localStorageWalletSessionToken";
 import { parseJwt } from "@/helpers/parseJwt";
@@ -14,7 +14,7 @@ export const fetchWalletApi = async <ResponseType>(
 
   if (!token) {
     document.dispatchEvent(new CustomEvent(WALLET_SESSION_EXPIRED_EVENT));
-    throw new Error(SESSION_EXPIRED);
+    throw new Error(WALLET_SESSION_EXPIRED);
   }
 
   const jwt = parseJwt(token);
@@ -22,7 +22,7 @@ export const fetchWalletApi = async <ResponseType>(
 
   if (minRemaining <= 0) {
     document.dispatchEvent(new CustomEvent(WALLET_SESSION_EXPIRED_EVENT));
-    throw new Error(SESSION_EXPIRED);
+    throw new Error(WALLET_SESSION_EXPIRED);
   }
 
   const headers: HeadersInit = {
@@ -37,10 +37,5 @@ export const fetchWalletApi = async <ResponseType>(
     headers,
   });
 
-  if (response.status === 401) {
-    document.dispatchEvent(new CustomEvent(WALLET_SESSION_EXPIRED_EVENT));
-    throw new Error(SESSION_EXPIRED);
-  }
-
-  return (await handleApiResponse(response)) as ResponseType;
+  return handleWalletApiResponse<ResponseType>(response);
 };

--- a/src/store/ducks/walletAccount.ts
+++ b/src/store/ducks/walletAccount.ts
@@ -2,7 +2,7 @@ import { createAsyncThunk, createSlice, PayloadAction } from "@reduxjs/toolkit";
 
 import { getEmbeddedWalletProfile } from "@/api/embeddedWallet";
 import { refreshPasskeyToken } from "@/api/passkeyRefresh";
-import { SESSION_EXPIRED, WALLET_SESSION_EXPIRED_EVENT } from "@/constants/settings";
+import { WALLET_SESSION_EXPIRED, WALLET_SESSION_EXPIRED_EVENT } from "@/constants/settings";
 import { RootState } from "@/store";
 import {
   AppError,
@@ -48,10 +48,10 @@ export const refreshWalletTokenAction = createAsyncThunk<
     const response = await refreshPasskeyToken(token);
     return response.token;
   } catch (error: unknown) {
-    if (error === SESSION_EXPIRED) {
+    if (error === WALLET_SESSION_EXPIRED) {
       document.dispatchEvent(new CustomEvent(WALLET_SESSION_EXPIRED_EVENT));
       return rejectWithValue({
-        errorString: SESSION_EXPIRED,
+        errorString: WALLET_SESSION_EXPIRED,
       });
     }
 
@@ -82,10 +82,10 @@ export const fetchWalletProfileAction = createAsyncThunk<
     const profile = await getEmbeddedWalletProfile(token);
     return profile;
   } catch (error) {
-    if (error === SESSION_EXPIRED) {
+    if (error === WALLET_SESSION_EXPIRED) {
       document.dispatchEvent(new CustomEvent(WALLET_SESSION_EXPIRED_EVENT));
       return rejectWithValue({
-        errorString: SESSION_EXPIRED,
+        errorString: WALLET_SESSION_EXPIRED,
       });
     }
 

--- a/src/store/ducks/walletAccount.ts
+++ b/src/store/ducks/walletAccount.ts
@@ -2,7 +2,7 @@ import { createAsyncThunk, createSlice, PayloadAction } from "@reduxjs/toolkit";
 
 import { getEmbeddedWalletProfile } from "@/api/embeddedWallet";
 import { refreshPasskeyToken } from "@/api/passkeyRefresh";
-import { SESSION_EXPIRED } from "@/constants/settings";
+import { SESSION_EXPIRED, WALLET_SESSION_EXPIRED_EVENT } from "@/constants/settings";
 import { RootState } from "@/store";
 import {
   AppError,
@@ -49,6 +49,7 @@ export const refreshWalletTokenAction = createAsyncThunk<
     return response.token;
   } catch (error: unknown) {
     if (error === SESSION_EXPIRED) {
+      document.dispatchEvent(new CustomEvent(WALLET_SESSION_EXPIRED_EVENT));
       return rejectWithValue({
         errorString: SESSION_EXPIRED,
       });
@@ -81,6 +82,13 @@ export const fetchWalletProfileAction = createAsyncThunk<
     const profile = await getEmbeddedWalletProfile(token);
     return profile;
   } catch (error) {
+    if (error === SESSION_EXPIRED) {
+      document.dispatchEvent(new CustomEvent(WALLET_SESSION_EXPIRED_EVENT));
+      return rejectWithValue({
+        errorString: SESSION_EXPIRED,
+      });
+    }
+
     const appError = error as AppError;
     const message = appError?.message || "Unable to fetch wallet profile";
 
@@ -155,9 +163,6 @@ const walletAccountSlice = createSlice({
       state.status = "ERROR";
       state.isTokenRefresh = false;
       state.errorString = action.payload?.errorString;
-      if (action.payload?.errorString === SESSION_EXPIRED) {
-        state.isSessionExpired = true;
-      }
     });
     builder.addCase(fetchWalletProfileAction.pending, (state) => {
       state.status = "PENDING";


### PR DESCRIPTION
### What

This adds session token expiry checks to the embedded wallet API helpers so that the user is logged out when the token expires.

### Why

Previously, users stayed logged in despite their JWTs expiring.

### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] Preview deployment works as expected
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Ready for production
