### PR TITLE
SDP-1634: Hide Customize Invite Message for KWA and Refactor to Avoid State-sync effects

### DIFF
--- a/src/pages/DisbursementDraftDetails.tsx
+++ b/src/pages/DisbursementDraftDetails.tsx
@@ -1,12 +1,23 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
 import { Badge, Heading, Link, Button, Icon, Modal } from "@stellar/design-system";
-import { useDispatch } from "react-redux";
-import { useRedux } from "@/hooks/useRedux";
-import { useDownloadCsvFile } from "@/hooks/useDownloadCsvFile";
-import { useAllBalances } from "@/hooks/useAllBalances";
 import { BigNumber } from "bignumber.js";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useDispatch } from "react-redux";
+import { useNavigate, useParams } from "react-router-dom";
 
+import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { DisbursementButtons } from "@/components/DisbursementButtons";
+import { DisbursementDetails } from "@/components/DisbursementDetails";
+import { DisbursementInstructions } from "@/components/DisbursementInstructions";
+import { DisbursementInviteMessage } from "@/components/DisbursementInviteMessage";
+import { ErrorWithExtras } from "@/components/ErrorWithExtras";
+import { NotificationWithButtons } from "@/components/NotificationWithButtons";
+import { SectionHeader } from "@/components/SectionHeader";
+import { Toast } from "@/components/Toast";
+import { Routes } from "@/constants/settings";
+import { csvTotalAmount } from "@/helpers/csvTotalAmount";
+import { useAllBalances } from "@/hooks/useAllBalances";
+import { useDownloadCsvFile } from "@/hooks/useDownloadCsvFile";
+import { useRedux } from "@/hooks/useRedux";
 import { AppDispatch } from "@/store";
 import {
   getDisbursementDetailsAction,
@@ -22,19 +33,6 @@ import {
   setDraftIdAction,
   submitDisbursementSavedDraftAction,
 } from "@/store/ducks/disbursementDrafts";
-
-import { Breadcrumbs } from "@/components/Breadcrumbs";
-import { Routes } from "@/constants/settings";
-import { DisbursementButtons } from "@/components/DisbursementButtons";
-import { DisbursementDetails } from "@/components/DisbursementDetails";
-import { DisbursementInstructions } from "@/components/DisbursementInstructions";
-import { DisbursementInviteMessage } from "@/components/DisbursementInviteMessage";
-import { ErrorWithExtras } from "@/components/ErrorWithExtras";
-import { NotificationWithButtons } from "@/components/NotificationWithButtons";
-import { SectionHeader } from "@/components/SectionHeader";
-import { Toast } from "@/components/Toast";
-import { csvTotalAmount } from "@/helpers/csvTotalAmount";
-
 import { DisbursementDraft, DisbursementStep, hasWallet } from "@/types";
 
 export const DisbursementDraftDetails = () => {
@@ -69,6 +67,7 @@ export const DisbursementDraftDetails = () => {
   const notificationRef = useRef<HTMLDivElement | null>(null);
   const apiError = disbursementDrafts.errorString;
   const isLoading = disbursementDetails.status === "PENDING";
+  const isKWA = hasWallet(draftDetails?.details.registrationContactType);
 
   useEffect(() => {
     if (!apiError && !isCsvUpdatedSuccess && !isResponseSuccess) return;
@@ -111,6 +110,7 @@ export const DisbursementDraftDetails = () => {
     disbursementDetails.status,
   ]);
 
+  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     setDraftDetails(disbursementDetails);
     dispatch(setDraftIdAction(disbursementDetails.details.id));
@@ -160,6 +160,7 @@ export const DisbursementDraftDetails = () => {
       setFutureBalance(Number(assetBalance) - BigNumber(totalAmount).toNumber());
     }
   }, [draftDetails?.details.stats?.totalAmount, draftDetails?.details.asset.code, allBalances]);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   const resetState = () => {
     setCurrentStep("edit");
@@ -313,9 +314,7 @@ export const DisbursementDraftDetails = () => {
 
     const successMessageArray: string[] = [
       "Payments will begin automatically",
-      hasWallet(draftDetails?.details.registrationContactType)
-        ? ""
-        : " to receivers who have registered their wallet",
+      isKWA ? "" : " to receivers who have registered their wallet",
       ". Click 'View' to track your disbursement in real-time.",
     ].filter((m) => Boolean(m));
 
@@ -354,11 +353,12 @@ export const DisbursementDraftDetails = () => {
               futureBalance={futureBalance}
               csvFile={csvFile}
             />
-            <DisbursementInviteMessage
-              isEditMessage={false}
-              draftMessage={draftDetails?.details.receiverRegistrationMessageTemplate}
-            />
-
+            {!isKWA && (
+              <DisbursementInviteMessage
+                isEditMessage={false}
+                draftMessage={draftDetails?.details.receiverRegistrationMessageTemplate}
+              />
+            )}
             {renderButtons("confirmation")}
           </form>
         </>
@@ -387,10 +387,12 @@ export const DisbursementDraftDetails = () => {
             details={draftDetails?.details}
             futureBalance={futureBalance}
           />
-          <DisbursementInviteMessage
-            isEditMessage={false}
-            draftMessage={draftDetails?.details.receiverRegistrationMessageTemplate}
-          />
+          {!isKWA && (
+            <DisbursementInviteMessage
+              isEditMessage={false}
+              draftMessage={draftDetails?.details.receiverRegistrationMessageTemplate}
+            />
+          )}
           <DisbursementInstructions
             variant={"preview"}
             csvFile={csvFile}


### PR DESCRIPTION
### What

1. conditionally render `DisbursementInviteMessage` only when the registration contact type is a KWA
2. refactor DisbursementsNew/DisbursementDraftDetails to remove “setState inside useEffect”:
    - In `DisbursementsNew`, replaced the useEffect that watched `disbursementDrafts.actionType` to flip save/submit UI state with direct logic inside `handleSaveDraft` and `handleSubmitDisbursement`
    - In `DisbursementDraftDetails`,  replaced the effects that mirrored `Redux data`,  watched `disbursementDrafts.isCsvFileUpdated` and  `actionType === "submit"` with with direct state updates inside their own handler function

### Why

```
 error  Error: Calling setState synchronously within an effect can trigger cascading renders
[1] 
[1] Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. In general, the body of an effect should do one or both of the following:
[1] * Update external systems with the latest state from React.
[1] * Subscribe for updates from some external system, calling setState in a callback function when external state changes.
[1] 
[1] Calling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. (https://react.dev/learn/you-might-not-need-an-effect).
```
### Known limitations

N/A

### Checklist

- [ ] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [ ] PR has a focused scope and doesn't mix features with refactoring
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] Preview deployment works as expected
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Ready for production
