### PR TITLE
SDP-1634: Hide Customize Invite Message for KWA 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Improve Wallet History Component functionality:
    - Filter spam/dust transactions (<0.001), show last 10 payments, add Stellar Expert link, add info tooltip, and increase asset amount decimal precision from 2 to 3 digits. [#414](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/414)
    - Add support for contract accounts operations in the Wallet History component. [#419](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/419)
+- Hide 'Customize Invite' section for KWA disbursements. [#432](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/432)
 
 ### Security and Dependencies
 

--- a/src/pages/DisbursementDraftDetails.tsx
+++ b/src/pages/DisbursementDraftDetails.tsx
@@ -1,12 +1,23 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
 import { Badge, Heading, Link, Button, Icon, Modal } from "@stellar/design-system";
-import { useDispatch } from "react-redux";
-import { useRedux } from "@/hooks/useRedux";
-import { useDownloadCsvFile } from "@/hooks/useDownloadCsvFile";
-import { useAllBalances } from "@/hooks/useAllBalances";
 import { BigNumber } from "bignumber.js";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useDispatch } from "react-redux";
+import { useNavigate, useParams } from "react-router-dom";
 
+import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { DisbursementButtons } from "@/components/DisbursementButtons";
+import { DisbursementDetails } from "@/components/DisbursementDetails";
+import { DisbursementInstructions } from "@/components/DisbursementInstructions";
+import { DisbursementInviteMessage } from "@/components/DisbursementInviteMessage";
+import { ErrorWithExtras } from "@/components/ErrorWithExtras";
+import { NotificationWithButtons } from "@/components/NotificationWithButtons";
+import { SectionHeader } from "@/components/SectionHeader";
+import { Toast } from "@/components/Toast";
+import { Routes } from "@/constants/settings";
+import { csvTotalAmount } from "@/helpers/csvTotalAmount";
+import { useAllBalances } from "@/hooks/useAllBalances";
+import { useDownloadCsvFile } from "@/hooks/useDownloadCsvFile";
+import { useRedux } from "@/hooks/useRedux";
 import { AppDispatch } from "@/store";
 import {
   getDisbursementDetailsAction,
@@ -22,19 +33,6 @@ import {
   setDraftIdAction,
   submitDisbursementSavedDraftAction,
 } from "@/store/ducks/disbursementDrafts";
-
-import { Breadcrumbs } from "@/components/Breadcrumbs";
-import { Routes } from "@/constants/settings";
-import { DisbursementButtons } from "@/components/DisbursementButtons";
-import { DisbursementDetails } from "@/components/DisbursementDetails";
-import { DisbursementInstructions } from "@/components/DisbursementInstructions";
-import { DisbursementInviteMessage } from "@/components/DisbursementInviteMessage";
-import { ErrorWithExtras } from "@/components/ErrorWithExtras";
-import { NotificationWithButtons } from "@/components/NotificationWithButtons";
-import { SectionHeader } from "@/components/SectionHeader";
-import { Toast } from "@/components/Toast";
-import { csvTotalAmount } from "@/helpers/csvTotalAmount";
-
 import { DisbursementDraft, DisbursementStep, hasWallet } from "@/types";
 
 export const DisbursementDraftDetails = () => {
@@ -69,6 +67,7 @@ export const DisbursementDraftDetails = () => {
   const notificationRef = useRef<HTMLDivElement | null>(null);
   const apiError = disbursementDrafts.errorString;
   const isLoading = disbursementDetails.status === "PENDING";
+  const isKWA = hasWallet(draftDetails?.details.registrationContactType);
 
   useEffect(() => {
     if (!apiError && !isCsvUpdatedSuccess && !isResponseSuccess) return;
@@ -111,6 +110,7 @@ export const DisbursementDraftDetails = () => {
     disbursementDetails.status,
   ]);
 
+  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     setDraftDetails(disbursementDetails);
     dispatch(setDraftIdAction(disbursementDetails.details.id));
@@ -160,6 +160,7 @@ export const DisbursementDraftDetails = () => {
       setFutureBalance(Number(assetBalance) - BigNumber(totalAmount).toNumber());
     }
   }, [draftDetails?.details.stats?.totalAmount, draftDetails?.details.asset.code, allBalances]);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   const resetState = () => {
     setCurrentStep("edit");
@@ -313,9 +314,7 @@ export const DisbursementDraftDetails = () => {
 
     const successMessageArray: string[] = [
       "Payments will begin automatically",
-      hasWallet(draftDetails?.details.registrationContactType)
-        ? ""
-        : " to receivers who have registered their wallet",
+      isKWA ? "" : " to receivers who have registered their wallet",
       ". Click 'View' to track your disbursement in real-time.",
     ].filter((m) => Boolean(m));
 
@@ -354,11 +353,12 @@ export const DisbursementDraftDetails = () => {
               futureBalance={futureBalance}
               csvFile={csvFile}
             />
-            <DisbursementInviteMessage
-              isEditMessage={false}
-              draftMessage={draftDetails?.details.receiverRegistrationMessageTemplate}
-            />
-
+            {!isKWA && (
+              <DisbursementInviteMessage
+                isEditMessage={false}
+                draftMessage={draftDetails?.details.receiverRegistrationMessageTemplate}
+              />
+            )}
             {renderButtons("confirmation")}
           </form>
         </>
@@ -387,10 +387,12 @@ export const DisbursementDraftDetails = () => {
             details={draftDetails?.details}
             futureBalance={futureBalance}
           />
-          <DisbursementInviteMessage
-            isEditMessage={false}
-            draftMessage={draftDetails?.details.receiverRegistrationMessageTemplate}
-          />
+          {!isKWA && (
+            <DisbursementInviteMessage
+              isEditMessage={false}
+              draftMessage={draftDetails?.details.receiverRegistrationMessageTemplate}
+            />
+          )}
           <DisbursementInstructions
             variant={"preview"}
             csvFile={csvFile}

--- a/src/pages/DisbursementsNew.tsx
+++ b/src/pages/DisbursementsNew.tsx
@@ -1,9 +1,25 @@
-import { useEffect, useRef, useState } from "react";
 import { Badge, Card, Heading } from "@stellar/design-system";
+import { BigNumber } from "bignumber.js";
+import { useEffect, useRef, useState } from "react";
 import { useDispatch } from "react-redux";
 import { useNavigate } from "react-router-dom";
-import { BigNumber } from "bignumber.js";
 
+import { AccountBalances } from "@/components/AccountBalances";
+import { Breadcrumbs } from "@/components/Breadcrumbs";
+import { DisbursementButtons } from "@/components/DisbursementButtons";
+import { DisbursementDetails } from "@/components/DisbursementDetails";
+import { DisbursementInstructions } from "@/components/DisbursementInstructions";
+import { DisbursementInviteMessage } from "@/components/DisbursementInviteMessage";
+import { ErrorWithExtras } from "@/components/ErrorWithExtras";
+import { InfoTooltip } from "@/components/InfoTooltip";
+import { NotificationWithButtons } from "@/components/NotificationWithButtons";
+import { SectionHeader } from "@/components/SectionHeader";
+import { Title } from "@/components/Title";
+import { Toast } from "@/components/Toast";
+import { Routes } from "@/constants/settings";
+import { csvTotalAmount } from "@/helpers/csvTotalAmount";
+import { useAllBalances } from "@/hooks/useAllBalances";
+import { useRedux } from "@/hooks/useRedux";
 import { AppDispatch } from "@/store";
 import {
   clearDisbursementDraftsErrorAction,
@@ -11,24 +27,6 @@ import {
   saveDisbursementDraftAction,
   submitDisbursementNewDraftAction,
 } from "@/store/ducks/disbursementDrafts";
-import { useRedux } from "@/hooks/useRedux";
-import { useAllBalances } from "@/hooks/useAllBalances";
-import { Routes } from "@/constants/settings";
-import { csvTotalAmount } from "@/helpers/csvTotalAmount";
-
-import { Breadcrumbs } from "@/components/Breadcrumbs";
-import { SectionHeader } from "@/components/SectionHeader";
-import { Toast } from "@/components/Toast";
-import { DisbursementDetails } from "@/components/DisbursementDetails";
-import { DisbursementInviteMessage } from "@/components/DisbursementInviteMessage";
-import { DisbursementInstructions } from "@/components/DisbursementInstructions";
-import { DisbursementButtons } from "@/components/DisbursementButtons";
-import { NotificationWithButtons } from "@/components/NotificationWithButtons";
-import { InfoTooltip } from "@/components/InfoTooltip";
-import { AccountBalances } from "@/components/AccountBalances";
-import { ErrorWithExtras } from "@/components/ErrorWithExtras";
-import { Title } from "@/components/Title";
-
 import { Disbursement, DisbursementStep, hasWallet } from "@/types";
 
 export const DisbursementsNew = () => {
@@ -48,11 +46,16 @@ export const DisbursementsNew = () => {
 
   const isDraftEnabled = isDetailsValid;
   const isReviewEnabled = isDraftEnabled && Boolean(csvFile);
+  const isKWA = hasWallet(draftDetails?.registrationContactType);
 
   const dispatch: AppDispatch = useDispatch();
   const navigate = useNavigate();
 
   const apiError = disbursementDrafts.status === "ERROR" && disbursementDrafts.errorString;
+
+  const handleScrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
 
   useEffect(() => {
     if (!apiError && !isSavedDraftMessageVisible && !isResponseSuccess) return;
@@ -60,6 +63,7 @@ export const DisbursementsNew = () => {
     notificationRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [isSavedDraftMessageVisible, apiError, isResponseSuccess]);
 
+  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     handleScrollToTop();
     if (disbursementDrafts.newDraftId && disbursementDrafts.status === "SUCCESS") {
@@ -78,6 +82,7 @@ export const DisbursementsNew = () => {
       }
     }
   }, [disbursementDrafts.actionType, disbursementDrafts.newDraftId, disbursementDrafts.status]);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   const { allBalances } = useAllBalances();
 
@@ -110,10 +115,6 @@ export const DisbursementsNew = () => {
         }),
       );
     }
-  };
-
-  const handleScrollToTop = () => {
-    window.scrollTo({ top: 0, behavior: "smooth" });
   };
 
   const handleReview = (event: React.FormEvent<HTMLFormElement>) => {
@@ -223,7 +224,9 @@ export const DisbursementsNew = () => {
             details={draftDetails}
             futureBalance={futureBalance}
           />
-          <DisbursementInviteMessage isEditMessage={false} draftMessage={customMessage} />
+          {!isKWA && (
+            <DisbursementInviteMessage isEditMessage={false} draftMessage={customMessage} />
+          )}
           <DisbursementInstructions
             variant="preview"
             csvFile={csvFile}
@@ -239,9 +242,7 @@ export const DisbursementsNew = () => {
 
     const successMessageArray: string[] = [
       "Payments will begin automatically",
-      hasWallet(draftDetails?.registrationContactType)
-        ? ""
-        : " to receivers who have registered their wallet",
+      isKWA ? "" : " to receivers who have registered their wallet",
       ". Click 'View' to track your disbursement in real-time.",
     ].filter((m) => Boolean(m));
 
@@ -278,7 +279,9 @@ export const DisbursementsNew = () => {
               futureBalance={futureBalance}
               csvFile={csvFile}
             />
-            <DisbursementInviteMessage isEditMessage={false} draftMessage={customMessage} />
+            {!isKWA && (
+              <DisbursementInviteMessage isEditMessage={false} draftMessage={customMessage} />
+            )}
 
             {renderButtons("confirmation")}
           </form>
@@ -315,17 +318,19 @@ export const DisbursementsNew = () => {
             }}
           />
 
-          <DisbursementInviteMessage
-            isEditMessage={true}
-            onChange={(updatedDisbursementInviteMessage) => {
-              setCustomMessage(updatedDisbursementInviteMessage);
-            }}
-            disabledReasonForTooltip={
-              hasWallet(draftDetails?.registrationContactType)
-                ? "No invitation message will be sent because you're registering receivers with wallets addresses."
-                : undefined
-            }
-          />
+          {!isKWA && (
+            <DisbursementInviteMessage
+              isEditMessage={true}
+              onChange={(updatedDisbursementInviteMessage) => {
+                setCustomMessage(updatedDisbursementInviteMessage);
+              }}
+              disabledReasonForTooltip={
+                hasWallet(draftDetails?.registrationContactType)
+                  ? "No invitation message will be sent because you're registering receivers with wallets addresses."
+                  : undefined
+              }
+            />
+          )}
           <DisbursementInstructions
             variant="upload"
             csvFile={csvFile}


### PR DESCRIPTION
### What

1. conditionally render `DisbursementInviteMessage` only when the registration contact type is **NOT** a KWA
2. Suppress the `set-state-in-effect` lint error for now, tarcking in https://stellarorg.atlassian.net/browse/SDP-1969

### Why

```
 error  Error: Calling setState synchronously within an effect can trigger cascading renders
[1] 
[1] Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. In general, the body of an effect should do one or both of the following:
[1] * Update external systems with the latest state from React.
[1] * Subscribe for updates from some external system, calling setState in a callback function when external state changes.
[1] 
[1] Calling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. (https://react.dev/learn/you-might-not-need-an-effect).
```
### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] Preview deployment works as expected
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Ready for production
