### PR TITLE
ESLint: set custom import order + state in effect warning

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,7 +15,7 @@ export default tseslint.config(
     },
     plugins: {
       "react-hooks": reactHooks,
-      "import": importPlugin,
+      import: importPlugin,
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
@@ -29,18 +29,94 @@ export default tseslint.config(
       "react/jsx-key": "off",
       "react/no-unescaped-entities": "off",
       "import/named": "off",
-      "import/order": ["error", {
-        "groups": [
-          "builtin",
-          "external",
-          "internal",
-          "parent",
-          "sibling",
-          "index"
-        ],
-        "newlines-between": "always",
-        "alphabetize": { "order": "asc" }
-      }]
+      "import/order": [
+        "error",
+        {
+          groups: [
+            "builtin",
+            "external",
+            "internal",
+            "parent",
+            "sibling",
+            "index",
+            "object",
+            "type",
+          ],
+          pathGroups: [
+            {
+              pattern: "react",
+              group: "external",
+              position: "before",
+            },
+            {
+              pattern: "@stellar/**",
+              group: "external",
+              position: "after",
+            },
+            {
+              pattern: "@/components/**",
+              group: "internal",
+              position: "before",
+            },
+            {
+              pattern: "@/pages/**",
+              group: "internal",
+              position: "after",
+            },
+            {
+              pattern: "@/store/**",
+              group: "internal",
+              position: "after",
+            },
+            {
+              pattern: "@/constants/**",
+              group: "internal",
+              position: "after",
+            },
+            {
+              pattern: "@/api/**",
+              group: "internal",
+              position: "after",
+            },
+            {
+              pattern: "@/apiQueries/**",
+              group: "internal",
+              position: "after",
+            },
+            {
+              pattern: "@/helpers/**",
+              group: "internal",
+              position: "after",
+            },
+            {
+              pattern: "@/hooks/**",
+              group: "internal",
+              position: "after",
+            },
+            {
+              pattern: "@/types",
+              group: "type",
+              position: "after",
+            },
+            {
+              pattern: "./**/*.scss",
+              group: "sibling",
+              position: "after",
+            },
+            {
+              pattern: "./**/*.css",
+              group: "sibling",
+              position: "after",
+            },
+          ],
+          pathGroupsExcludedImportTypes: ["react"],
+          "newlines-between": "always",
+          alphabetize: {
+            order: "asc",
+            caseInsensitive: true,
+          },
+        },
+      ],
     },
   },
 );

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,6 +28,7 @@ export default tseslint.config(
       "react/prop-types": "off",
       "react/jsx-key": "off",
       "react/no-unescaped-entities": "off",
+      "react-hooks/set-state-in-effect": "warn",
       "import/named": "off",
       "import/order": [
         "error",


### PR DESCRIPTION
### What

- Update ESLint import order to match our custom order
- Changed the `react-hooks/set-state-in-effect` from error to warning (this is a new trend to consider this an anti-pattern; we'll fix it over time)
- This is a config update only, not sure if this requires CHANGELOG update

### Why

Make linting more consistent in PRs.

### Known limitations

N/A

### Checklist

- [ ] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] Preview deployment works as expected
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [x] Ready for production
