### PR TITLE
Use `&` for selectors in layout css

### DIFF
--- a/src/components/EmbeddedWalletLayout/styles.scss
+++ b/src/components/EmbeddedWalletLayout/styles.scss
@@ -10,69 +10,29 @@
   box-sizing: border-box;
   overflow-x: hidden;
   overflow-y: auto;
-}
 
-.EmbeddedWalletHeader {
-  position: sticky;
-  top: 0;
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: pxToRem(16px);
-  height: pxToRem(56px);
-  background: var(--sds-clr-gray-01);
-  border-bottom: 1px solid var(--sds-clr-gray-05);
-  z-index: 2;
-}
+  &__container {
+    width: 100%;
+    max-width: pxToRem(720px);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: pxToRem(24px) pxToRem(16px);
+  }
 
-.EmbeddedWalletHeader__brand {
-  display: flex;
-  align-items: center;
-  gap: pxToRem(8px);
-  font-size: pxToRem(16px);
-}
+  &__stack {
+    --ew-card-min: #{pxToRem(360px)};
+    --ew-card-max: #{pxToRem(560px)};
+    --ew-card-padding: #{pxToRem(32px)} #{pxToRem(24px)};
+    --ew-card-padding-sm: #{pxToRem(24px)} #{pxToRem(16px)};
 
-.EmbeddedWalletHeader__brand img {
-  height: pxToRem(24px);
-  width: auto;
-  object-fit: contain;
-  display: block;
-}
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0;
+  }
 
-.EmbeddedWalletHeader__title {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  color: var(--sds-clr-gray-11);
-  font-size: pxToRem(12px);
-  font-weight: 500;
-  margin: 0;
-}
-
-.EmbeddedWalletLayout__container {
-  width: 100%;
-  max-width: pxToRem(720px);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: pxToRem(24px) pxToRem(16px);
-}
-
-.EmbeddedWalletLayout__stack {
-  --ew-card-min: #{pxToRem(360px)};
-  --ew-card-max: #{pxToRem(560px)};
-  --ew-card-padding: #{pxToRem(32px)} #{pxToRem(24px)};
-  --ew-card-padding-sm: #{pxToRem(24px)} #{pxToRem(16px)};
-
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0;
-}
-
-.EmbeddedWalletLayout {
   &__notices {
     width: 100%;
     display: flex;
@@ -130,103 +90,149 @@
       }
     }
   }
+
+  &__cardWrapper {
+    width: clamp(var(--ew-card-min), 94vw, var(--ew-card-max));
+    background: var(--sds-clr-gray-01);
+    border-radius: pxToRem(8px);
+    box-shadow: none;
+    padding: var(--ew-card-padding);
+
+    > .Card {
+      width: 100%;
+      height: auto;
+      background: transparent;
+      border: none;
+      box-shadow: none;
+      padding: 0;
+    }
+  }
+
+  & .EmbeddedWalletSubtitle {
+    margin: 0;
+    text-align: left;
+    color: var(--sds-clr-gray-11);
+    line-height: pxToRem(22px);
+    font-size: pxToRem(16px);
+    font-weight: var(--sds-fw-medium);
+  }
 }
 
-.EmbeddedWalletLayout__cardWrapper {
-  width: clamp(var(--ew-card-min), 94vw, var(--ew-card-max));
-  background: var(--sds-clr-gray-01);
-  border-radius: pxToRem(8px);
-  box-shadow: none;
-  padding: var(--ew-card-padding);
-}
-
-.EmbeddedWalletLayout__cardWrapper > .Card {
+.EmbeddedWalletHeader {
+  position: sticky;
+  top: 0;
   width: 100%;
-  height: auto;
-  background: transparent;
-  border: none;
-  box-shadow: none;
-  padding: 0;
-}
-
-.EmbeddedWalletCard__content {
-  display: flex;
-  flex-direction: column;
-  gap: pxToRem(24px);
-}
-
-.EmbeddedWalletCard__content .EmbeddedWalletText {
-  display: flex;
-  flex-direction: column;
-  gap: pxToRem(16px);
-}
-
-.EmbeddedWalletCard__logo {
-  width: pxToRem(44px);
-  height: pxToRem(44px);
-  border-radius: pxToRem(12px);
-  background-color: var(--sds-clr-gray-02);
   display: flex;
   align-items: center;
-  justify-content: center;
-  font-weight: 700;
-  color: var(--sds-clr-gray-11);
-  margin: 0 auto;
-  overflow: hidden;
+  justify-content: space-between;
+  padding: pxToRem(16px);
+  height: pxToRem(56px);
+  background: var(--sds-clr-gray-01);
+  border-bottom: 1px solid var(--sds-clr-gray-05);
+  z-index: 2;
+
+  &__brand {
+    display: flex;
+    align-items: center;
+    gap: pxToRem(8px);
+    font-size: pxToRem(16px);
+
+    img {
+      height: pxToRem(24px);
+      width: auto;
+      object-fit: contain;
+      display: block;
+    }
+  }
+
+  &__title {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    color: var(--sds-clr-gray-11);
+    font-size: pxToRem(12px);
+    font-weight: 500;
+    margin: 0;
+  }
 }
 
-.EmbeddedWalletCard__logo img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
+.EmbeddedWalletCard {
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: pxToRem(24px);
 
-.EmbeddedWalletLayout .EmbeddedWalletSubtitle {
-  margin: 0;
-  text-align: left;
-  color: var(--sds-clr-gray-11);
-  line-height: pxToRem(22px);
-  font-size: pxToRem(16px);
-  font-weight: var(--sds-fw-medium);
+    .EmbeddedWalletText {
+      display: flex;
+      flex-direction: column;
+      gap: pxToRem(16px);
+    }
+  }
+
+  &__logo {
+    width: pxToRem(44px);
+    height: pxToRem(44px);
+    border-radius: pxToRem(12px);
+    background-color: var(--sds-clr-gray-02);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    color: var(--sds-clr-gray-11);
+    margin: 0 auto;
+    overflow: hidden;
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+  }
 }
 
 @media (max-width: 480px) {
-  .EmbeddedWalletLayout__container {
-    padding: pxToRem(16px);
-    align-items: flex-start;
+  .EmbeddedWalletLayout {
+    &__container {
+      padding: pxToRem(16px);
+      align-items: flex-start;
+    }
+
+    &__stack {
+      align-items: stretch;
+    }
+
+    &__cardWrapper {
+      width: 100%;
+      max-width: pxToRem(500px);
+      padding: var(--ew-card-padding-sm);
+    }
+
+    &__notices {
+      align-items: stretch;
+    }
+
+    &__noticeItem {
+      width: 100%;
+      max-width: pxToRem(500px);
+    }
   }
 
-  .EmbeddedWalletLayout__stack {
-    align-items: stretch;
-  }
-
-  .EmbeddedWalletLayout__cardWrapper {
-    width: 100%;
-    max-width: pxToRem(500px);
-    padding: var(--ew-card-padding-sm);
-  }
-
-  .EmbeddedWalletLayout__notices {
-    align-items: stretch;
-  }
-
-  .EmbeddedWalletLayout__noticeItem {
-    width: 100%;
-    max-width: pxToRem(500px);
-  }
-
-  .EmbeddedWalletCard__logo {
-    width: pxToRem(48px);
-    height: pxToRem(48px);
+  .EmbeddedWalletCard {
+    &__logo {
+      width: pxToRem(48px);
+      height: pxToRem(48px);
+    }
   }
 }
 
 @media (max-width: 360px) {
-  .EmbeddedWalletLayout__cardWrapper {
-    width: 100%;
-  }
+  .EmbeddedWalletLayout {
+    &__cardWrapper {
+      width: 100%;
+    }
 
-  .EmbeddedWalletLayout__noticeItem {
-    max-width: 100%;
+    &__noticeItem {
+      max-width: 100%;
+    }
   }
 }


### PR DESCRIPTION
### What

This switches the `&` syntax in the embedded wallet layout css.

### Why

Use consistent syntax in the file

### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] Preview deployment works as expected
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Ready for production
