### PR TITLE
SDP-1959: Fix login page flashing on home page refresh

### DIFF
--- a/src/apiQueries/useWalletBalance.ts
+++ b/src/apiQueries/useWalletBalance.ts
@@ -7,7 +7,7 @@ import { ApiStellarAccountBalance, AppError, EmbeddedWalletSupportedAsset } from
 
 export const useWalletBalance = (
   contractAddress: string | undefined,
-  assets: EmbeddedWalletSupportedAsset[],
+  assets?: EmbeddedWalletSupportedAsset[],
 ) => {
   const query = useQuery<ApiStellarAccountBalance[], AppError>({
     queryKey: ["wallet-balance", contractAddress],
@@ -17,7 +17,7 @@ export const useWalletBalance = (
       }
 
       const rpcServer = createAuthenticatedRpcServer("wallet");
-      const assetDescriptors = assets.map((asset) => ({
+      const assetDescriptors = (assets ?? []).map((asset) => ({
         code: asset.code,
         issuer: asset.issuer || null,
       }));
@@ -28,7 +28,7 @@ export const useWalletBalance = (
         assets: assetDescriptors,
       });
     },
-    enabled: Boolean(contractAddress),
+    enabled: Boolean(contractAddress && assets !== undefined),
     refetchInterval: 10000,
   });
 

--- a/src/components/WalletPrivateRoute.tsx
+++ b/src/components/WalletPrivateRoute.tsx
@@ -1,7 +1,8 @@
 import { Navigate, useLocation } from "react-router-dom";
 
-import { useRedux } from "@/hooks/useRedux";
 import { Routes } from "@/constants/settings";
+
+import { useRedux } from "@/hooks/useRedux";
 
 type WalletPrivateRouteProps = {
   children: React.ReactElement;
@@ -10,6 +11,10 @@ type WalletPrivateRouteProps = {
 export const WalletPrivateRoute = ({ children }: WalletPrivateRouteProps) => {
   const { walletAccount } = useRedux("walletAccount");
   const location = useLocation();
+
+  if (walletAccount.isRestoringSession) {
+    return null;
+  }
 
   const isAuthenticated =
     walletAccount.isAuthenticated &&

--- a/src/pages/EmbeddedWallet.tsx
+++ b/src/pages/EmbeddedWallet.tsx
@@ -1,20 +1,28 @@
-import { Button, Heading, Notification } from "@stellar/design-system";
 import { useCallback, useEffect, useMemo, useState } from "react";
+
 import { useDispatch } from "react-redux";
 import { useLocation, useNavigate } from "react-router-dom";
+
+import { Button, Heading, Notification } from "@stellar/design-system";
+
+import { Box } from "@/components/Box";
+import { EmbeddedWalletLayout } from "@/components/EmbeddedWalletLayout";
+
+import { getOrgLogoAction } from "@/store/ducks/organization";
+import { setWalletTokenAction } from "@/store/ducks/walletAccount";
+
+import { Routes } from "@/constants/settings";
 
 import { useCreateEmbeddedWallet } from "@/apiQueries/useCreateEmbeddedWallet";
 import { usePasskeyAuthentication } from "@/apiQueries/usePasskeyAuthentication";
 import { usePasskeyRefresh } from "@/apiQueries/usePasskeyRefresh";
 import { usePasskeyRegistration } from "@/apiQueries/usePasskeyRegistration";
-import { Box } from "@/components/Box";
-import { EmbeddedWalletLayout } from "@/components/EmbeddedWalletLayout";
-import { Routes } from "@/constants/settings";
+
 import { getSdpTenantName } from "@/helpers/getSdpTenantName";
+
 import { useRedux } from "@/hooks/useRedux";
+
 import { AppDispatch } from "@/store";
-import { getOrgLogoAction } from "@/store/ducks/organization";
-import { setWalletTokenAction } from "@/store/ducks/walletAccount";
 
 export const EmbeddedWallet = () => {
   const dispatch: AppDispatch = useDispatch();
@@ -175,6 +183,17 @@ export const EmbeddedWallet = () => {
         disabled: isLoading,
         isLoading: isAuthenticating,
       };
+
+  // Hide login UI while restoring or already authenticated to prevent flashing.
+  const shouldHideLoginUI =
+    walletAccount.isRestoringSession ||
+    (walletAccount.isAuthenticated &&
+      Boolean(walletAccount.contractAddress) &&
+      !walletAccount.isSessionExpired);
+
+  if (shouldHideLoginUI) {
+    return null;
+  }
 
   return (
     <EmbeddedWalletLayout

--- a/src/pages/EmbeddedWalletHome.tsx
+++ b/src/pages/EmbeddedWalletHome.tsx
@@ -62,7 +62,7 @@ export const EmbeddedWalletHome = () => {
     data: balanceData,
     isLoading: isLoadingBalance,
     refetch: refetchBalance,
-  } = useWalletBalance(contractAddress, supportedAssets ?? []);
+  } = useWalletBalance(contractAddress, supportedAssets);
 
   const nonZeroWalletBalances = useMemo<ApiStellarAccountBalance[]>(() => {
     if (!balanceData) {

--- a/src/store/ducks/walletAccount.ts
+++ b/src/store/ducks/walletAccount.ts
@@ -26,6 +26,7 @@ const initialState: WalletAccountInitialState = {
   isAuthenticated: false,
   isSessionExpired: false,
   isTokenRefresh: false,
+  isRestoringSession: true,
   isVerificationPending: false,
   pendingAsset: undefined,
   supportedAssets: undefined,
@@ -114,6 +115,7 @@ const walletAccountSlice = createSlice({
       state.status = "SUCCESS";
       state.errorString = undefined;
       state.isTokenRefresh = false;
+      state.isRestoringSession = false;
     },
     setWalletTokenAction: (state, { payload }: PayloadAction<string>) => {
       state.token = payload;
@@ -122,6 +124,7 @@ const walletAccountSlice = createSlice({
       state.status = "SUCCESS";
       state.errorString = undefined;
       state.isTokenRefresh = false;
+      state.isRestoringSession = false;
     },
     clearWalletInfoAction: (state) => {
       state.token = "";
@@ -136,6 +139,7 @@ const walletAccountSlice = createSlice({
       state.receiverContact = undefined;
       state.status = undefined;
       state.errorString = undefined;
+      state.isRestoringSession = false;
     },
     restoreWalletSession: (state, action: PayloadAction<string>) => {
       state.token = action.payload;
@@ -144,10 +148,18 @@ const walletAccountSlice = createSlice({
       state.errorString = undefined;
       state.isTokenRefresh = false;
       state.isAuthenticated = true;
+      state.isRestoringSession = false;
     },
     walletSessionExpiredAction: (state) => {
       state.isSessionExpired = true;
       state.status = "ERROR";
+      state.isRestoringSession = false;
+    },
+    startWalletSessionRestore: (state) => {
+      state.isRestoringSession = true;
+    },
+    finishWalletSessionRestore: (state) => {
+      state.isRestoringSession = false;
     },
   },
   extraReducers: (builder) => {
@@ -193,4 +205,6 @@ export const {
   clearWalletInfoAction,
   restoreWalletSession,
   walletSessionExpiredAction,
+  startWalletSessionRestore,
+  finishWalletSessionRestore,
 } = walletAccountSlice.actions;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -42,6 +42,7 @@ export type WalletAccountInitialState = {
   isAuthenticated: boolean;
   isSessionExpired: boolean;
   isTokenRefresh: boolean;
+  isRestoringSession: boolean;
   isVerificationPending: boolean;
   pendingAsset?: ApiAsset;
   walletProfile?: EmbeddedWalletProfileResponse;


### PR DESCRIPTION
### What

- Added `isRestoringSession` to the wallet slice so the app knows when it’s still hydrating a wallet session from localStorage. This blocks the “Log in to wallet” screen from appearing while state is reloading after a refresh.
- `EmbeddedWallet.tsx` now returns early via `shouldHideLoginUI` whenever the wallet is restoring or already authenticated, stopping the login form from flashing right before we redirect to /wallet/home.
- `useWalletBalance` now waits for supported assets before querying, so the balance card shows “Loading assets…” until the profile is ready instead of flashing “No assets.”

### Why

UI fix

### Known limitations

N/A

### Checklist

- [ ] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [ ] PR has a focused scope and doesn't mix features with refactoring
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] Preview deployment works as expected
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Ready for production
