### PR TITLE
Fix: SEP-45 ledger footprint verify missing `webAuthContractId`

### DIFF
--- a/src/helpers/sep45Authentication/sign.ts
+++ b/src/helpers/sep45Authentication/sign.ts
@@ -126,7 +126,7 @@ const verifyLedgerFootprint = ({
     throw new Error("Simulation response missing read/write footprint");
   }
 
-  const allowedLedgerAddresses = new Set([contractAddress, serverSigningKey]);
+  const allowedLedgerAddresses = new Set([contractAddress, serverSigningKey, webAuthContractId]);
 
   for (const ledgerKey of readWrite) {
     const entryType = ledgerKey.switch().value;


### PR DESCRIPTION
### What

As title.

### Why

```
- The transaction's ledger footprint `read_write` set contains only
     `contract_data` entries where:
     - The `contract` is the **Client Account** address, and the `key` is
       `ledger_key_nonce`.
     - The `contract` is the **Server Account**, and the `key` is
       `ledger_key_nonce`.
     - (Optional) if an authorization entry for the **Client Domain Account**
       was present in the challenge, the `contract` is the **Client Domain
       Account**, and the `key` is `ledger_key_nonce`.
     - (Optional) The `contract` is the `WEB_AUTH_CONTRACT_ID`, and the `key`
       is `ledger_key_contract_instance` if the web authentication contract
       instance has been archived.
```

### Known limitations

N/A

### Checklist

- [ ] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [ ] PR has a focused scope and doesn't mix features with refactoring
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] Preview deployment works as expected
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Ready for production
