### PR TITLE
SDP-1998: RPC client allowHttp based on API_URL protocol instead of NODE_ENV

### DIFF
--- a/src/helpers/createAuthenticatedRpcServer.ts
+++ b/src/helpers/createAuthenticatedRpcServer.ts
@@ -1,6 +1,7 @@
 import { rpc } from "@stellar/stellar-sdk";
 
 import { API_URL } from "@/constants/envVariables";
+
 import { getSdpTenantName } from "@/helpers/getSdpTenantName";
 import { localStorageSessionToken } from "@/helpers/localStorageSessionToken";
 import { localStorageWalletSessionToken } from "@/helpers/localStorageWalletSessionToken";
@@ -20,9 +21,9 @@ export const createAuthenticatedRpcServer = (
 
   const rpcProxyUrl = `${API_URL}/rpc/${authType}`;
 
-  const isDevelopment = process.env.NODE_ENV === "development";
+  const isHttpUrl = new URL(rpcProxyUrl).protocol === "http:";
   return new rpc.Server(rpcProxyUrl, {
-    allowHttp: isDevelopment,
+    allowHttp: isHttpUrl,
     headers: {
       Authorization: `Bearer ${token}`,
       "SDP-Tenant-Name": getSdpTenantName(organizationName),


### PR DESCRIPTION
### What

Changed allowHttp configuration in createAuthenticatedRpcServer.ts to be determined by the API_URL protocol instead of NODE_ENV.

### Why

The embedded wallet verification flow was silently failing in production Docker builds:

1. Production builds set NODE_ENV=production, causing allowHttp=false
2. When API_URL is HTTP (e.g., http://localhost:8000), the Stellar SDK's rpc.Server silently rejects requests
3. This blocked RPC calls (getNetwork(), getLatestLedger()) needed before the passkey prompt, causing the "Start verification" button to load indefinitely

The fix respects the configured API_URL protocol—if the developer explicitly configures HTTP, the RPC client should allow it. This is consistent with all other API calls which already use the same API_URL.

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] Preview deployment works as expected
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Ready for production
