### PR TITLE
SDP-2001: Fix "None" verification type label in disbursement draft view

### DIFF
--- a/src/components/DisbursementDetails/index.tsx
+++ b/src/components/DisbursementDetails/index.tsx
@@ -199,7 +199,7 @@ const deriveFormState = ({
         : "-",
     verification: details.verificationField
       ? VerificationFieldMap[details.verificationField] || details.verificationField
-      : isWalletAddressProvided
+      : isWalletAddressProvided || isEmbeddedWallet
         ? NONE_VERIFICATION_VALUE
         : "-",
   };


### PR DESCRIPTION
### What

Fix the label, it should be displayed as "None" instead of "-"
<img width="629" height="374" alt="Screenshot 2026-01-23 at 5 33 25 PM" src="https://github.com/user-attachments/assets/774f78cb-5b5c-4641-9b23-f716b29476ff" />

### Why

<img width="907" height="990" alt="Screenshot 2026-01-23 at 12 27 12 PM" src="https://github.com/user-attachments/assets/b7a2cdb7-a677-49c9-981b-3bc8a320c453" />

### Known limitations

N/A

### Checklist

- [ ] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [ ] PR has a focused scope and doesn't mix features with refactoring
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] Preview deployment works as expected
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Ready for production
