### PR TITLE
SDP-2004 Automate release changelog generation and release notes

### DIFF
--- a/.github/workflows/automated_release_process.yml
+++ b/.github/workflows/automated_release_process.yml
@@ -50,7 +50,7 @@ jobs:
           git checkout -b release/${{ inputs.version }} origin/${{ github.ref_name }}
 
       - name: Install Node.js for tooling
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 

--- a/.github/workflows/automated_release_process.yml
+++ b/.github/workflows/automated_release_process.yml
@@ -48,9 +48,81 @@ jobs:
       - name: Create release/${{ inputs.version }} branch
         run: |
           git checkout -b release/${{ inputs.version }} origin/${{ github.ref_name }}
+
+      - name: Install Node.js for tooling
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install Copilot CLI
+        run: npm install -g @github/copilot@0.0.410
+
+      - name: Bump version in package.json
+        run: |
           sed -i 's/"version": ".*"/"version": "${{ inputs.version }}"/' package.json
           git add package.json
-          git commit -m "chore: bump version to ${{ inputs.version }}"
+
+      - name: Generate CHANGELOG entry
+        env:
+          GH_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          VERSION="${{ inputs.version }}"
+          REPO="${{ github.repository }}"
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
+          BASE="${LAST_TAG:-$(git rev-list --max-parents=0 HEAD)}"
+
+          git log "$BASE"..HEAD --pretty=format:"%h %s" --no-merges > /tmp/commits.txt
+          awk '
+            /^## \[Unreleased\]/ { in_section=1; next }
+            /^## \[/ { if (in_section) exit }
+            in_section { print }
+          ' CHANGELOG.md > /tmp/unreleased-body.md
+
+          : > /tmp/new-entries.md
+          if [ -s /tmp/commits.txt ] && [ -n "${GH_TOKEN:-}" ]; then
+            copilot -sp "$(cat <<PROMPT
+          You are a CHANGELOG generator for ${REPO}.
+
+          Below are git commits since the last release (${BASE}):
+          $(cat /tmp/commits.txt)
+
+          The current Unreleased section of CHANGELOG.md is:
+          $(cat /tmp/unreleased-body.md)
+
+          Your job:
+          1. Identify commits NOT already covered in the Unreleased section above.
+          2. For each missing commit, categorize it: Added, Changed, Fixed, or Security and Dependencies.
+          3. Format: - Description [#PR](https://github.com/${REPO}/pull/PR)
+          4. Extract PR numbers from subjects (e.g. (#1049) -> 1049).
+          5. Skip merge commits and chore-only commits that don't add functionality.
+          6. Output ONLY the new entries grouped by category (### Added, ### Changed, etc). No header, no explanation, no code blocks.
+          7. If all commits are already covered, output nothing.
+          PROMPT
+          )" > /tmp/new-entries.md 2>/dev/null || true
+          else
+            echo "Skipping Copilot changelog gap fill (no commits or missing COPILOT_GITHUB_TOKEN)"
+          fi
+
+          python3 scripts/release/update_changelog.py \
+            --changelog CHANGELOG.md \
+            --version "$VERSION" \
+            --repo "$REPO" \
+            --base "$BASE" \
+            --new-entries-file /tmp/new-entries.md
+
+          if ! git diff --quiet CHANGELOG.md 2>/dev/null; then
+            git add CHANGELOG.md
+          fi
+
+      - name: Commit automated changes
+        run: |
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: automated release preparation for ${{ inputs.version }}"
+          else
+            echo "No changes to commit"
+          fi
           git push origin release/${{ inputs.version }}
 
       - name: Create main PR
@@ -86,13 +158,27 @@ jobs:
             --reviewer "${{ env.REVIEWER }}")
           echo "dev_pr_url=${DEV_PR_URL}" >> $GITHUB_OUTPUT
 
+      - name: Extract release notes from CHANGELOG
+        run: |
+          VERSION="${{ inputs.version }}"
+          python3 -c "
+          import re, sys
+          text = open('CHANGELOG.md').read()
+          m = re.search(r'(## \[' + re.escape('$VERSION') + r'\].*?)(?=\n## \[|\Z)', text, re.DOTALL)
+          sys.stdout.write(m.group(1) if m else '')
+          " > /tmp/release-notes.md
+
+          if [ ! -s /tmp/release-notes.md ]; then
+            echo "Initial draft for release \`$VERSION\`" > /tmp/release-notes.md
+          fi
+
       - name: Create Draft Release
         id: create_release
         run: |
-          RELEASE_URL=$(gh release create ${{ inputs.version }} \
+          RELEASE_URL=$(gh release create "${{ inputs.version }}" \
             --title "${{ inputs.version }}" \
             --draft \
-            --notes "Initial draft for release \`${{ inputs.version }}\`")
+            --notes-file /tmp/release-notes.md)
           echo "release_url=${RELEASE_URL}" >> $GITHUB_OUTPUT
 
       - name: Create Issue

--- a/.github/workflows/templates/release-issue.md
+++ b/.github/workflows/templates/release-issue.md
@@ -19,5 +19,6 @@ Release `{{version}}`
 ### Publishing the Release
 
 - [ ] After the main PR is merged, publish the draft release: {{ release_url }} -> [Release Page](https://github.com/stellar/stellar-disbursement-platform-frontend/releases/tag/{{version}})
+  - Release notes have been pre-populated from CHANGELOG.md — review before publishing
   - [ ] Verify the Docker image is published to [Docker Hub](https://hub.docker.com/r/stellar/stellar-disbursement-platform-frontend/tags)
 - [ ] Propagate the helmchart version update to the [stellar/helm-charts](https://github.com/stellar/helm-charts) repository

--- a/.github/workflows/templates/release-pr-dev.md
+++ b/.github/workflows/templates/release-pr-dev.md
@@ -1,7 +1,10 @@
 Release `{{version}}` to `dev`
 
-### Pending
+### Pending Tasks
 
-- [ ] Merge the main PR {{ main_pr_url }}
-- [ ] Rebase this branch onto `main`
-- [ ] 🚨 Merge this PR using the **`Merge pull request`** button
+- [ ] **Merge the main PR first**: {{ main_pr_url }}
+- [ ] **Rebase this branch** onto `main` after main PR is merged
+
+### Merge Instructions 🚨
+
+- [ ] Merge this PR using the **`Merge pull request`** button (do NOT squash or rebase)

--- a/.github/workflows/templates/release-pr-main.md
+++ b/.github/workflows/templates/release-pr-main.md
@@ -1,7 +1,19 @@
 Release `{{version}}` to `main`
 
-### Pending
+### Automated Preparation ✅
+
+The following tasks have been completed automatically by the release workflow:
 
 - [x] Bump version in package.json
-- [ ] Update CHANGELOG.md
-- [ ] 🚨 Merge this PR using the **`Merge pull request`** button
+- [x] Update CHANGELOG.md release entry (Unreleased + optional AI gap-fill)
+
+### Manual Review Required 👀
+
+Please review the automated changes before merging:
+
+- [ ] **CHANGELOG.md** - Verify release notes are accurate and include missing merged PRs
+- [ ] **Version consistency** - Verify the version bump is correct
+
+### Merge Instructions 🚨
+
+- [ ] Merge this PR using the **`Merge pull request`** button (do NOT squash or rebase)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## [Unreleased]
 
 - Wallet Providers
   - add a new wallet page [#458](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/458)

--- a/scripts/release/update_changelog.py
+++ b/scripts/release/update_changelog.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Promote CHANGELOG Unreleased section into a versioned release section."
+    )
+    parser.add_argument("--changelog", default="CHANGELOG.md")
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--new-entries-file", default="")
+    return parser.parse_args()
+
+
+def load_optional_file(path: str) -> str:
+    if not path:
+        return ""
+    file_path = Path(path)
+    if not file_path.exists():
+        return ""
+    return file_path.read_text(encoding="utf-8").strip()
+
+
+def main() -> int:
+    args = parse_args()
+
+    changelog_path = Path(args.changelog)
+    changelog_text = changelog_path.read_text(encoding="utf-8")
+
+    pattern = r"## \[Unreleased\](.*?)(?=\n## \[|\Z)"
+    match = re.search(pattern, changelog_text, re.DOTALL)
+    if not match:
+        raise RuntimeError("CHANGELOG.md is missing the '## [Unreleased]' section")
+
+    unreleased_body = match.group(1).strip()
+    new_entries = load_optional_file(args.new_entries_file)
+
+    chunks = [part for part in [unreleased_body, new_entries] if part]
+    body = "\n\n".join(chunks).strip() if chunks else ""
+    if not body:
+        body = f"- Release {args.version}"
+
+    release_url = f"https://github.com/{args.repo}/releases/tag/{args.version}"
+    compare_url = f"https://github.com/{args.repo}/compare/{args.base}...{args.version}"
+    version_header = f"## [{args.version}]({release_url}) ([diff]({compare_url}))"
+
+    replacement = f"## [Unreleased]\n\n{version_header}\n\n{body}\n"
+    updated = changelog_text[: match.start()] + replacement + changelog_text[match.end() :]
+    changelog_path.write_text(updated, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### What

- Enhanced the automated release workflow to generate CHANGELOG entries
  using Copilot CLI (optional) and a new `update_changelog.py` script
  that promotes the `[Unreleased]` section into a versioned release entry.
- Draft GitHub releases are now pre-populated with release notes
  extracted from CHANGELOG.md instead of a generic placeholder.
- Updated release PR templates to reflect the new automated steps and
  clarify manual review responsibilities.
- Updated CHANGELOG.md heading from `## Unreleased` to `## [Unreleased]`
  to follow the Keep a Changelog convention used by the backend.
- This PR mirrors changes already introduced in https://github.com/stellar/stellar-disbursement-platform-backend/pull/1062

### Why

- Reduce manual release work — version bump, changelog promotion, and
  release notes were previously done by hand on every release.
- Align the frontend release process with the backend (stellar/stellar-disbursement-platform-backend#1062).

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] Preview deployment works as expected
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Ready for production
