### PR TITLE
SDP-2065: Add option to disable receiver wallet invitations per tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- Add Settings toggle to disable automatic receiver invitations. [#517](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/517)
+- Add Settings toggle to disable automatic receiver invitations. [#518](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/518)
 
 ## [6.2.0](https://github.com/stellar/stellar-disbursement-platform-frontend/releases/tag/6.2.0) ([diff](https://github.com/stellar/stellar-disbursement-platform-frontend/compare/6.1.0...6.2.0))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Add Settings toggle to disable automatic receiver invitations. [#517](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/517)
+
 ## [6.2.0](https://github.com/stellar/stellar-disbursement-platform-frontend/releases/tag/6.2.0) ([diff](https://github.com/stellar/stellar-disbursement-platform-frontend/compare/6.1.0...6.2.0))
 
 ### Added

--- a/src/apiQueries/useUpdateOrgReceiverInvitationsDisabled.ts
+++ b/src/apiQueries/useUpdateOrgReceiverInvitationsDisabled.ts
@@ -1,0 +1,39 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { API_URL } from "@/constants/envVariables";
+
+import { fetchApi } from "@/helpers/fetchApi";
+
+import { AppError } from "@/types";
+
+export const useUpdateOrgReceiverInvitationsDisabled = () => {
+  const mutation = useMutation({
+    mutationFn: (isDisabled: boolean) => {
+      const formData = new FormData();
+
+      formData.append("data", `{"receiver_invitations_disabled": ${isDisabled}}`);
+
+      return fetchApi(
+        `${API_URL}/organization`,
+        {
+          method: "PATCH",
+          body: formData,
+        },
+        { omitContentType: true },
+      );
+    },
+  });
+
+  return {
+    ...mutation,
+    error: mutation.error as AppError,
+    data: mutation.data as { message: string },
+    mutateAsync: async (isEnabled: boolean) => {
+      try {
+        await mutation.mutateAsync(isEnabled);
+      } catch {
+        // do nothing
+      }
+    },
+  };
+};

--- a/src/apiQueries/useUpdateOrgReceiverInvitationsDisabled.ts
+++ b/src/apiQueries/useUpdateOrgReceiverInvitationsDisabled.ts
@@ -28,9 +28,9 @@ export const useUpdateOrgReceiverInvitationsDisabled = () => {
     ...mutation,
     error: mutation.error as AppError,
     data: mutation.data as { message: string },
-    mutateAsync: async (isEnabled: boolean) => {
+    mutateAsync: async (isDisabled: boolean) => {
       try {
-        await mutation.mutateAsync(isEnabled);
+        await mutation.mutateAsync(isDisabled);
       } catch {
         // do nothing
       }

--- a/src/components/SettingsReceiverInvitationsDisabled.tsx
+++ b/src/components/SettingsReceiverInvitationsDisabled.tsx
@@ -1,0 +1,76 @@
+import { useEffect } from "react";
+
+import { useDispatch } from "react-redux";
+
+import { Card, Loader, Notification, Toggle } from "@stellar/design-system";
+
+import { ErrorWithExtras } from "@/components/ErrorWithExtras";
+
+import { getOrgInfoAction } from "@/store/ducks/organization";
+
+import { useUpdateOrgReceiverInvitationsDisabled } from "@/apiQueries/useUpdateOrgReceiverInvitationsDisabled";
+
+import { useRedux } from "@/hooks/useRedux";
+
+import { AppDispatch } from "@/store";
+
+export const SettingsReceiverInvitationsDisabled = () => {
+  const { organization } = useRedux("organization");
+
+  const dispatch: AppDispatch = useDispatch();
+
+  const { mutateAsync, isPending, error, isSuccess } = useUpdateOrgReceiverInvitationsDisabled();
+
+  useEffect(() => {
+    if (isSuccess) {
+      dispatch(getOrgInfoAction());
+    }
+  }, [dispatch, isSuccess]);
+
+  const handleToggleChange = () => {
+    mutateAsync(!organization.data.receiver_invitations_disabled);
+  };
+
+  const renderContent = () => {
+    return (
+      <div className="SdpSettings">
+        <div className="SdpSettings__row">
+          <div className="SdpSettings__item">
+            <label className="SdpSettings__label" htmlFor="receiver-invitations-disabled">
+              Disable receiver invitations
+            </label>
+            <div className="Toggle__wrapper">
+              {isPending ? <Loader size="1rem" /> : null}
+              <Toggle
+                id="receiver-invitations-disabled"
+                checked={Boolean(organization.data.receiver_invitations_disabled)}
+                onChange={handleToggleChange}
+                disabled={isPending}
+                fieldSize="sm"
+              />
+            </div>
+          </div>
+          <div className="Note">
+            Toggle this option to stop the platform from sending invitation messages (SMS or email)
+            to receivers. When disabled, you are responsible for delivering registration links to
+            receivers through your own channels.
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <>
+      {error ? (
+        <Notification variant="error" title="Error" isFilled={true}>
+          <ErrorWithExtras appError={error} />
+        </Notification>
+      ) : null}
+
+      <Card>
+        <div className="CardStack__card">{renderContent()}</div>
+      </Card>
+    </>
+  );
+};

--- a/src/components/SettingsReceiverInvitationsDisabled.tsx
+++ b/src/components/SettingsReceiverInvitationsDisabled.tsx
@@ -52,8 +52,8 @@ export const SettingsReceiverInvitationsDisabled = () => {
           </div>
           <div className="Note">
             Toggle this option to stop the platform from sending invitation messages (SMS or email)
-            to receivers. When disabled, you are responsible for delivering registration links to
-            receivers through your own channels.
+            to receivers. When this option is enabled, you are responsible for delivering
+            registration links to receivers through your own channels.
           </div>
         </div>
       </div>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -8,6 +8,7 @@ import { SettingsEnableMemoTracking } from "@/components/SettingsEnableMemoTrack
 import { SettingsEnablePaymentCancellation } from "@/components/SettingsEnablePaymentCancellation";
 import { SettingsEnableReceiverInvitationRetry } from "@/components/SettingsEnableReceiverInvitationRetry";
 import { SettingsEnableShortLinking } from "@/components/SettingsEnableShortLinking";
+import { SettingsReceiverInvitationsDisabled } from "@/components/SettingsReceiverInvitationsDisabled";
 import { SettingsTeamMembers } from "@/components/SettingsTeamMembers";
 
 export const Settings = () => {
@@ -38,6 +39,9 @@ export const Settings = () => {
 
         {/* Enable automatic ready payments cancellation */}
         <SettingsEnablePaymentCancellation />
+
+        {/* Disable receiver invitations */}
+        <SettingsReceiverInvitationsDisabled />
 
         {/* Enable Receiver Invitation retry */}
         <SettingsEnableReceiverInvitationRetry />

--- a/src/store/ducks/organization.ts
+++ b/src/store/ducks/organization.ts
@@ -3,10 +3,11 @@ import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import { getOrgInfo } from "@/api/getOrgInfo";
 import { getOrgLogo } from "@/api/getOrgLogo";
 import { patchOrgInfo } from "@/api/patchOrgInfo";
+
 import { endSessionIfTokenInvalid } from "@/helpers/endSessionIfTokenInvalid";
 import { normalizeApiError } from "@/helpers/normalizeApiError";
 import { refreshSessionToken } from "@/helpers/refreshSessionToken";
-import { RootState } from "@/store";
+
 import {
   ApiError,
   ApiOrgInfo,
@@ -14,6 +15,8 @@ import {
   OrganizationInitialState,
   RejectMessage,
 } from "@/types";
+
+import { RootState } from "@/store";
 
 export const getOrgInfoAction = createAsyncThunk<
   ApiOrgInfo,
@@ -129,6 +132,7 @@ const initialState: OrganizationInitialState = {
     baseUrl: "",
     mfa_disabled: undefined,
     captcha_disabled: undefined,
+    receiver_invitations_disabled: undefined,
   },
   updateMessage: undefined,
   status: undefined,
@@ -173,6 +177,7 @@ const organizationSlice = createSlice({
         paymentCancellationPeriodDays: Number(action.payload.payment_cancellation_period_days || 0),
         mfa_disabled: action.payload.mfa_disabled,
         captcha_disabled: action.payload.captcha_disabled,
+        receiver_invitations_disabled: action.payload.receiver_invitations_disabled,
         distributionAccount: {
           circleWalletId: action.payload.distribution_account?.circle_wallet_id || "",
           status: action.payload.distribution_account?.status || "",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -95,6 +95,7 @@ export type OrganizationInitialState = {
     paymentCancellationPeriodDays: number;
     mfa_disabled?: boolean;
     captcha_disabled?: boolean;
+    receiver_invitations_disabled?: boolean;
     distributionAccount?: {
       circleWalletId?: string;
       status: string;
@@ -869,6 +870,7 @@ export type ApiOrgInfo = {
   payment_cancellation_period_days: string;
   mfa_disabled?: boolean;
   captcha_disabled?: boolean;
+  receiver_invitations_disabled?: boolean;
   distribution_account?: {
     address?: string;
     circle_wallet_id?: string;


### PR DESCRIPTION
### What

Adds a new Settings toggle that lets organization admins disable the platform's automatic receiver invitation messages (SMS/email). When enabled, the SDP will skip sending invitations entirely, leaving delivery of registration links to the organization's own channels.

The change introduces a new `receiver_invitations_disabled` organization flag and exposes a toggle on the Settings page that PATCHes `/organization`.

<img width="682" height="179" alt="Screenshot 2026-04-27 at 10 45 46 AM" src="https://github.com/user-attachments/assets/d5232183-fda6-4923-950e-d039fc4cac36" />

### Why

Tenants need a way to pause outbound receiver wallet invitations.

### Known limitations

[TODO or N/A]

### Checklist

- [ ] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [ ] PR has a focused scope and doesn't mix features with refactoring
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] Preview deployment works as expected
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Ready for production
