### PR TITLE
Harden Claude release workflow security

### DIFF
--- a/.github/workflows/automated_release_process.yml
+++ b/.github/workflows/automated_release_process.yml
@@ -1,8 +1,8 @@
 name: Automated Release Process
 
 # Revoke all default GITHUB_TOKEN permissions at the workflow level. Each job
-# below opts in to what it needs. Defense in depth: a future job added without
-# its own `permissions:` block inherits nothing.
+# below opts in to what it needs, so a future job added without its own
+# `permissions:` block inherits nothing.
 permissions: {}
 
 on:
@@ -113,7 +113,6 @@ jobs:
         continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
-          show_full_output: false
           prompt: |
             Update CHANGELOG.md for release ${{ inputs.version }} of ${{ github.repository }}.
 

--- a/.github/workflows/automated_release_process.yml
+++ b/.github/workflows/automated_release_process.yml
@@ -1,10 +1,9 @@
 name: Automated Release Process
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  id-token: write
+# Revoke all default GITHUB_TOKEN permissions at the workflow level. Each job
+# below opts in to what it needs. Defense in depth: a future job added without
+# its own `permissions:` block inherits nothing.
+permissions: {}
 
 on:
   workflow_dispatch:
@@ -22,6 +21,11 @@ env:
 jobs:
   create-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
     env:
       ANTHROPIC_FEDERATION_RULE_ID: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID }}
       ANTHROPIC_ORGANIZATION_ID: ${{ vars.ANTHROPIC_ORGANIZATION_ID }}
@@ -109,6 +113,7 @@ jobs:
         continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
+          show_full_output: false
           prompt: |
             Update CHANGELOG.md for release ${{ inputs.version }} of ${{ github.repository }}.
 


### PR DESCRIPTION
### What

Apply a best practice to the `automated_release_process` workflow:

- Move the broad `contents: write`/`pull-requests: write`/`issues: write`/`id-token: write` scope from workflow level to the single job that needs it; set top-level `permissions: {}` so any future job added to this file inherits nothing by default.

### Why

This is pretty minor, but brings this workflow in line with the Claude-action security standards being applied across the stellar org (see `stellar/stellar-core` [PR #5258](https://github.com/stellar/stellar-core/pull/5258) and the [claude-code-action security guide](https://github.com/anthropics/claude-code-action/blob/main/docs/security.md)). Without `permissions: {}` at the workflow root, any future job added to this file would silently inherit the broad write scopes. Moving them to the job level limits the blast radius if this workflow expands in the future.