### PR TITLE
SDP-2092 chore: validate soroban auth entry invocation in useSendWalletPayment

### DIFF
--- a/src/apiQueries/useSendWalletPayment.ts
+++ b/src/apiQueries/useSendWalletPayment.ts
@@ -177,17 +177,16 @@ const validateTransferAuthEntries = (
   destination: string,
   amountInStroops: bigint,
 ) => {
-  const userEntries = authEntries.filter((entry) => {
-    return isAddressCredentialForContract(entry, contractAddress);
-  });
-
-  if (userEntries.length !== 1) {
-    throw createSimulationError(
-      `Expected exactly 1 auth entry for user wallet, got ${userEntries.length}`,
-    );
+  if (authEntries.length !== 1) {
+    throw createSimulationError(`Expected exactly 1 auth entry, got ${authEntries.length}`);
   }
 
-  const invocation = userEntries[0].rootInvocation();
+  const entry = authEntries[0];
+  if (!isAddressCredentialForContract(entry, contractAddress)) {
+    throw createSimulationError("Auth entry is not for expected user wallet contract");
+  }
+
+  const invocation = entry.rootInvocation();
   if (invocation.subInvocations().length) {
     throw createSimulationError(
       "Auth entry invocation authorizes sub-invocation(s) to another contract",
@@ -296,10 +295,6 @@ export const useSendWalletPayment = ({
         });
 
         authEntries = simulationResult.result?.auth ?? [];
-
-        if (!authEntries.length) {
-          throw createSimulationError("Simulation did not return any authorization entries");
-        }
 
         validateTransferAuthEntries(
           authEntries,

--- a/src/apiQueries/useSendWalletPayment.ts
+++ b/src/apiQueries/useSendWalletPayment.ts
@@ -12,6 +12,7 @@ import {
   TransactionBuilder,
   nativeToScVal,
   rpc,
+  scValToBigInt,
   xdr,
 } from "@stellar/stellar-sdk";
 
@@ -168,6 +169,87 @@ const simulateTransferOperation = async ({
   return simulationResult;
 };
 
+const validateTransferAuthEntries = (
+  authEntries: xdr.SorobanAuthorizationEntry[],
+  contractAddress: string,
+  assetContractId: string,
+  destination: string,
+  amountInStroops: bigint,
+) => {
+  const userEntries = authEntries.filter((entry) => {
+    if (entry.credentials().switch() !== xdr.SorobanCredentialsType.sorobanCredentialsAddress()) {
+      return false;
+    }
+
+    const addressCredentials = entry.credentials().address();
+    const address = addressCredentials.address();
+
+    if (address.switch() !== xdr.ScAddressType.scAddressTypeContract()) {
+      return false;
+    }
+
+    return Address.fromScAddress(address).toString() === contractAddress;
+  });
+
+  if (userEntries.length !== 1) {
+    throw createSimulationError(
+      `Expected exactly 1 auth entry for user wallet, got ${userEntries.length}`,
+    );
+  }
+
+  const invocation = userEntries[0].rootInvocation();
+  if (invocation.subInvocations().length) {
+    throw createSimulationError(
+      "Auth entry invocation authorizes sub-invocation(s) to another contract",
+    );
+  }
+
+  const contractFunction = invocation.function().contractFn();
+  const actualAssetContractId = Address.fromScAddress(
+    contractFunction.contractAddress(),
+  ).toString();
+  if (actualAssetContractId !== assetContractId) {
+    throw createSimulationError(
+      `Auth entry targets invalid assetContractId. Expected: ${assetContractId} but got: ${actualAssetContractId}`,
+    );
+  }
+
+  const actualFunctionName = contractFunction.functionName().toString();
+  if (actualFunctionName !== "transfer") {
+    throw createSimulationError(
+      `Auth entry calls invalid function name. Expected: transfer but got: ${actualFunctionName}`,
+    );
+  }
+
+  const args = contractFunction.args();
+  if (args.length !== 3) {
+    throw createSimulationError(
+      `Auth entry has wrong number of arguments. Expected: 3 but got: ${args.length}`,
+    );
+  }
+
+  const actualFrom = Address.fromScVal(args[0]).toString();
+  if (actualFrom !== contractAddress) {
+    throw createSimulationError(
+      `Auth entry "from" address mismatch. Expected: ${contractAddress} but got: ${actualFrom}`,
+    );
+  }
+
+  const actualTo = Address.fromScVal(args[1]).toString();
+  if (actualTo !== destination) {
+    throw createSimulationError(
+      `Auth entry "to" address mismatch. Expected: ${destination} but got: ${actualTo}`,
+    );
+  }
+
+  const actualAmount = scValToBigInt(args[2]);
+  if (actualAmount !== amountInStroops) {
+    throw createSimulationError(
+      `Auth entry amount mismatch. Expected: ${amountInStroops} but got: ${actualAmount}`,
+    );
+  }
+};
+
 export const useSendWalletPayment = ({
   contractAddress,
   credentialId,
@@ -216,23 +298,32 @@ export const useSendWalletPayment = ({
       });
 
       let simulationResult;
+      let authEntries: xdr.SorobanAuthorizationEntry[] = [];
       try {
         simulationResult = await simulateTransferOperation({
           operation: transferOperation,
           networkPassphrase,
         });
+
+        authEntries = simulationResult.result?.auth ?? [];
+
+        if (!authEntries.length) {
+          throw createSimulationError("Simulation did not return any authorization entries");
+        }
+
+        validateTransferAuthEntries(
+          authEntries,
+          contractAddress,
+          assetContractId,
+          destination,
+          amountInStroops,
+        );
       } catch (error) {
         if (isSimulationError(error)) {
           throw error;
         }
         const message = error instanceof Error ? error.message : "Simulation failed";
         throw createSimulationError(message);
-      }
-
-      const authEntries = simulationResult.result?.auth ?? [];
-
-      if (!authEntries.length) {
-        throw createSimulationError("Simulation did not return any authorization entries");
       }
 
       const signedAuthEntries = await signSorobanAuthorizationEntries({

--- a/src/apiQueries/useSendWalletPayment.ts
+++ b/src/apiQueries/useSendWalletPayment.ts
@@ -193,6 +193,13 @@ const validateTransferAuthEntries = (
     );
   }
 
+  if (
+    invocation.function().switch() !==
+    xdr.SorobanAuthorizedFunctionType.sorobanAuthorizedFunctionTypeContractFn()
+  ) {
+    throw createSimulationError("Auth entry does not authorize a contract function invocation");
+  }
+
   const contractFunction = invocation.function().contractFn();
   const actualAssetContractId = Address.fromScAddress(
     contractFunction.contractAddress(),

--- a/src/apiQueries/useSendWalletPayment.ts
+++ b/src/apiQueries/useSendWalletPayment.ts
@@ -27,6 +27,7 @@ import {
 } from "@/api/sponsoredTransactions";
 
 import { createAuthenticatedRpcServer } from "@/helpers/createAuthenticatedRpcServer";
+import { isAddressCredentialForContract } from "@/helpers/isAddressCredentialForContract";
 import { signSorobanAuthorizationEntries } from "@/helpers/signSorobanAuthorization";
 
 import type { AppError } from "@/types";
@@ -177,18 +178,7 @@ const validateTransferAuthEntries = (
   amountInStroops: bigint,
 ) => {
   const userEntries = authEntries.filter((entry) => {
-    if (entry.credentials().switch() !== xdr.SorobanCredentialsType.sorobanCredentialsAddress()) {
-      return false;
-    }
-
-    const addressCredentials = entry.credentials().address();
-    const address = addressCredentials.address();
-
-    if (address.switch() !== xdr.ScAddressType.scAddressTypeContract()) {
-      return false;
-    }
-
-    return Address.fromScAddress(address).toString() === contractAddress;
+    return isAddressCredentialForContract(entry, contractAddress);
   });
 
   if (userEntries.length !== 1) {

--- a/src/helpers/isAddressCredentialForContract.ts
+++ b/src/helpers/isAddressCredentialForContract.ts
@@ -1,0 +1,19 @@
+import { Address, xdr } from "@stellar/stellar-sdk";
+
+export const isAddressCredentialForContract = (
+  entry: xdr.SorobanAuthorizationEntry,
+  contractAddress: string,
+): boolean => {
+  if (entry.credentials().switch() !== xdr.SorobanCredentialsType.sorobanCredentialsAddress()) {
+    return false;
+  }
+
+  const addressCredentials = entry.credentials().address();
+  const address = addressCredentials.address();
+
+  if (address.switch() !== xdr.ScAddressType.scAddressTypeContract()) {
+    return false;
+  }
+
+  return Address.fromScAddress(address).toString() === contractAddress;
+};

--- a/src/helpers/signSorobanAuthorization.ts
+++ b/src/helpers/signSorobanAuthorization.ts
@@ -3,7 +3,9 @@ import { Buffer } from "buffer";
 import { p256 } from "@noble/curves/p256";
 import { startAuthentication } from "@simplewebauthn/browser";
 
-import { Address, hash, xdr } from "@stellar/stellar-sdk";
+import { hash, xdr } from "@stellar/stellar-sdk";
+
+import { isAddressCredentialForContract } from "@/helpers/isAddressCredentialForContract";
 
 type SignSorobanAuthorizationParams = {
   authEntries: xdr.SorobanAuthorizationEntry[];
@@ -25,24 +27,6 @@ const decodeBase64Url = (value: string): Buffer => {
   return Buffer.from(base64, "base64");
 };
 
-const shouldSignEntry = (
-  entry: xdr.SorobanAuthorizationEntry,
-  contractAddress: string,
-): boolean => {
-  if (entry.credentials().switch() !== xdr.SorobanCredentialsType.sorobanCredentialsAddress()) {
-    return false;
-  }
-
-  const addressCredentials = entry.credentials().address();
-  const address = addressCredentials.address();
-
-  if (address.switch() !== xdr.ScAddressType.scAddressTypeContract()) {
-    return false;
-  }
-
-  return Address.fromScAddress(address).toString() === contractAddress;
-};
-
 export const signSorobanAuthorizationEntries = async ({
   authEntries,
   contractAddress,
@@ -58,7 +42,7 @@ export const signSorobanAuthorizationEntries = async ({
   for (const entry of authEntries) {
     const cloned = xdr.SorobanAuthorizationEntry.fromXDR(entry.toXDR());
 
-    if (!shouldSignEntry(cloned, contractAddress)) {
+    if (!isAddressCredentialForContract(cloned, contractAddress)) {
       signedEntries.push(cloned);
       continue;
     }


### PR DESCRIPTION
### What

- Adds `validateTransferAuthEntries` to `useSendWalletPayment.ts`, which validates the Soroban authorization entry invocation returned by the RPC simulation before it is passed to the user's passkey for signing.

### Why

- In response to previous SDP-2090: The SDP embedded wallet uses WebAuthn passkeys to authorize Soroban transfers, with the authorization entry constructed from the RPC simulation response. Currently, client is blind-signing whatever the simulation returns.
- As a code hardening measure, the client now validates that the auth entry returned matches the transfer the user initiated before passkey prompt fires, verifying the token contract, function name, sender, recipient, and amount. 
- This mirrors the existing `validateAuthorizationEntry` pattern already in place for the SEP-45 authentication flow (`src/helpers/sep45Authentication/sign.ts`).

### Assumptions
- An honest SAC transfer simulation will return exactly one auth entry of address-credential type

### Design decisions
`authEntries.length !== 1` guard:
- Ensures that the honest RPC simulation only returned exactly one auth entry.
- Previous check for truthiness of `authEntries.length` now obsolete and removed.

Expanded try-catch block in `mutationFn`:`useSendWalletPayment`:
- `simulateTransferOperation`, and `validateTransferAuthEntries` all belong to the same phase (validate simulation response before signing), so they share one try-catch block. 
- Errors not explicitly handled by `validateTransferAuthEntries` (e.g. malformed ScVal type in args throwing a raw XDR error) are therefore still caught as simulationErrors.

Contract address credentials check extracted to shared helper `isAddressCredentialForContract.ts`:
- The logic validating address credentials required by `validateTransferAuthEntries` is identical to that in `signSorobanAuthorization.ts/shouldSignEntry`, therefore it is extracted to a shared helper to avoid repetition.

A note on testing:
- As the frontend repo contains no tests, the validator function was tested using a Claude-generated Node test script that ran an inline copy of the function with the help of the `@stellar/stellar-sdk`. 

### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [ ] `CHANGELOG.md` is updated (if applicable)
- [ ] Preview deployment works as expected
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Ready for production
