### PR TITLE
SDP-2094 chore: use claude-code-action native WIF inputs in release workflow

### DIFF
--- a/.github/workflows/automated_release_process.yml
+++ b/.github/workflows/automated_release_process.yml
@@ -25,13 +25,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-      id-token: write
-    env:
-      ANTHROPIC_FEDERATION_RULE_ID: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID }}
-      ANTHROPIC_ORGANIZATION_ID: ${{ vars.ANTHROPIC_ORGANIZATION_ID }}
-      ANTHROPIC_SERVICE_ACCOUNT_ID: ${{ vars.ANTHROPIC_SERVICE_ACCOUNT_ID }}
-      ANTHROPIC_WORKSPACE_ID: ${{ vars.ANTHROPIC_WORKSPACE_ID }}
-      ANTHROPIC_IDENTITY_TOKEN_FILE: /tmp/anthropic-gha-jwt
+      id-token: write # required: claude-code-action exchanges the GitHub OIDC token for a federated Anthropic token
     steps:
       - name: Validate version format
         run: |
@@ -73,42 +67,6 @@ jobs:
           echo "base=$BASE" >> $GITHUB_OUTPUT
           git log "$BASE"..HEAD --pretty=format:"%h %s%n%b---" > /tmp/commits.txt
 
-      - name: Fetch Anthropic federation JWT
-        run: |
-          set -euo pipefail
-          RESPONSE=$(curl -sS --fail-with-body \
-            -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=https://api.anthropic.com")
-          JWT=$(echo "$RESPONSE" | jq -r '.value // empty')
-          if [ -z "$JWT" ]; then
-            echo "::error::OIDC token response missing .value: $RESPONSE"
-            exit 1
-          fi
-          echo "$JWT" > "$ANTHROPIC_IDENTITY_TOKEN_FILE"
-
-      - name: Exchange JWT for Anthropic access token
-        id: anthropic_token
-        run: |
-          set -euo pipefail
-          JWT=$(cat "$ANTHROPIC_IDENTITY_TOKEN_FILE")
-          RESPONSE=$(jq -nc \
-            --arg assertion "$JWT" \
-            --arg rule "$ANTHROPIC_FEDERATION_RULE_ID" \
-            --arg org "$ANTHROPIC_ORGANIZATION_ID" \
-            --arg sa "$ANTHROPIC_SERVICE_ACCOUNT_ID" \
-            --arg workspace "$ANTHROPIC_WORKSPACE_ID" \
-            '{grant_type:"urn:ietf:params:oauth:grant-type:jwt-bearer",assertion:$assertion,federation_rule_id:$rule,organization_id:$org,service_account_id:$sa,workspace_id:$workspace}' \
-            | curl -sS -X POST https://api.anthropic.com/v1/oauth/token \
-              -H "content-type: application/json" \
-              --data-binary @-)
-          ACCESS_TOKEN=$(echo "$RESPONSE" | jq -r '.access_token // empty')
-          if [ -z "$ACCESS_TOKEN" ]; then
-            echo "::error::JWT exchange failed: $RESPONSE"
-            exit 1
-          fi
-          echo "::add-mask::$ACCESS_TOKEN"
-          echo "access_token=$ACCESS_TOKEN" >> "$GITHUB_OUTPUT"
-
       - name: Update CHANGELOG
         continue-on-error: true
         uses: anthropics/claude-code-action@v1
@@ -146,7 +104,10 @@ jobs:
             If the [Unreleased] section is empty AND there are no uncovered commits, use `- Release ${{ inputs.version }}` as the body.
 
             Use the Edit tool to modify CHANGELOG.md. Do not create or modify any other files.
-          claude_code_oauth_token: ${{ steps.anthropic_token.outputs.access_token }}
+          anthropic_organization_id: ${{ vars.ANTHROPIC_ORGANIZATION_ID }}
+          anthropic_service_account_id: ${{ vars.ANTHROPIC_SERVICE_ACCOUNT_ID }}
+          anthropic_federation_rule_id: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID }}
+          anthropic_workspace_id: ${{ vars.ANTHROPIC_WORKSPACE_ID }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: --max-turns 10 --allowedTools Read,Edit
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Use `claude-code-action`'s native Workload Identity Federation inputs in the automated release workflow. [#541](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/541)
+
 ## [6.5.0](https://github.com/stellar/stellar-disbursement-platform-frontend/releases/tag/6.5.0) ([diff](https://github.com/stellar/stellar-disbursement-platform-frontend/compare/6.2.0...6.5.0))
 
 ### Added


### PR DESCRIPTION
## What
Switch the automated release workflow to `anthropics/claude-code-action@v1`'s native Workload Identity Federation (WIF) inputs, and remove the hand-rolled OIDC token plumbing.

## Why
The action now supports federation natively, so this removes ~44 lines of brittle shell that duplicated logic the action already owns (including OIDC token expiry handling). Net result is simpler and matches the pattern used in `stellar/internal-agents`.