### PR TITLE
SDP-2096 chore: add date format requirement notice in UI for csv uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Add date format requirement notice in UI for csv uploads. [#542](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/542)
+
 ### Changed
 
 - Use `claude-code-action`'s native Workload Identity Federation inputs in the automated release workflow. [#541](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/541)

--- a/src/components/DisbursementDetails/index.tsx
+++ b/src/components/DisbursementDetails/index.tsx
@@ -511,15 +511,15 @@ export const DisbursementDetails: React.FC<DisbursementDetailsProps> = ({
       {(() => {
         const dateFormat = DATE_VERIFICATION_FORMATS[derived.selectValues.verificationField];
         return dateFormat ? (
-          <div className="DisbursementDetailsFields__notice">
-            <Notification variant="primary" title="Expected date of birth format">
+          <div className="DisbursementDetailsFields__dateFormatNotice">
+            <Notification variant="primary" title="Expected 'Date of Birth' format">
               <p>
                 Ensure dates are in <strong>{dateFormat.format}</strong>
                 {` format (e.g. ${dateFormat.example}).`}
               </p>
               <p>
-                Spreadsheet apps like Excel may automatically reformat dates when you open the CSV
-                file.
+                Spreadsheet apps like Excel may reformat dates when editing the CSV file. Check the
+                verification column before uploading.
               </p>
             </Notification>
           </div>

--- a/src/components/DisbursementDetails/index.tsx
+++ b/src/components/DisbursementDetails/index.tsx
@@ -509,10 +509,12 @@ export const DisbursementDetails: React.FC<DisbursementDetailsProps> = ({
       </Select>
 
       {(() => {
-        const dateFormat = DATE_VERIFICATION_FORMATS[derived.selectValues.verificationField];
+        const { verificationField } = derived.selectValues;
+        const dateFormat = DATE_VERIFICATION_FORMATS[verificationField];
+        const fieldLabel = VerificationFieldMap[verificationField] || verificationField;
         return dateFormat ? (
           <div className="DisbursementDetailsFields__dateFormatNotice">
-            <Notification variant="primary" title="Expected 'Date of Birth' format">
+            <Notification variant="primary" title={`Expected '${fieldLabel}' format`}>
               <p>
                 Ensure dates are in <strong>{dateFormat.format}</strong>
                 {` format (e.g. ${dateFormat.example}).`}

--- a/src/components/DisbursementDetails/index.tsx
+++ b/src/components/DisbursementDetails/index.tsx
@@ -36,6 +36,11 @@ const SDP_EMBEDDED_WALLET_NAME = "embedded wallet";
 const isSdpEmbeddedWallet = (walletName: string): boolean =>
   walletName.trim().toLowerCase() === SDP_EMBEDDED_WALLET_NAME;
 
+const DATE_VERIFICATION_FORMATS: Record<string, { format: string; example: string }> = {
+  DATE_OF_BIRTH: { format: "YYYY-MM-DD", example: "1994-09-30" },
+  YEAR_MONTH: { format: "YYYY-MM", example: "1994-09" },
+};
+
 interface DisbursementDetailsProps {
   variant: DisbursementStep;
   details?: Disbursement;
@@ -502,6 +507,24 @@ export const DisbursementDetails: React.FC<DisbursementDetailsProps> = ({
           </option>
         ))}
       </Select>
+
+      {(() => {
+        const dateFormat = DATE_VERIFICATION_FORMATS[derived.selectValues.verificationField];
+        return dateFormat ? (
+          <div className="DisbursementDetailsFields__notice">
+            <Notification variant="primary" title="Expected date of birth format">
+              <p>
+                Ensure dates are in <strong>{dateFormat.format}</strong>
+                {` format (e.g. ${dateFormat.example}).`}
+              </p>
+              <p>
+                Spreadsheet apps like Excel may automatically reformat dates when you open the CSV
+                file.
+              </p>
+            </Notification>
+          </div>
+        ) : null;
+      })()}
 
       <Input
         id={FieldId.NAME}

--- a/src/components/DisbursementDetails/styles.scss
+++ b/src/components/DisbursementDetails/styles.scss
@@ -23,4 +23,8 @@
   &__negative {
     color: var(--sds-clr-red-11);
   }
+
+  &__notice {
+    flex-basis: 100%;
+  }
 }

--- a/src/components/DisbursementDetails/styles.scss
+++ b/src/components/DisbursementDetails/styles.scss
@@ -24,7 +24,13 @@
     color: var(--sds-clr-red-11);
   }
 
-  &__notice {
+  &__dateFormatNotice {
     flex-basis: 100%;
+
+    .Notification__message p {
+      font-size: pxToRem(14px);
+      line-height: pxToRem(20px);
+      color: var(--sds-clr-gray-09);
+    }
   }
 }


### PR DESCRIPTION
### What

Add a clear, visible instruction in the "New disbursement" UI that stipulates the required date format is YYYY-MM-DD when Date of Birth option is selected.

### Why

User feedback indicates that users are getting confused by errors caused by uploading disbursement CSVs with malformed date formats. These are likely caused by automatic reformatting by Excel that varies depending on the user’s locale and that clashes with the single format accepted by the SDP (YYYY-MM-DD).

### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] Preview deployment works as expected
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [x] Ready for production
