### PR TITLE
SDP-2114 chore: select distribution account scope at API key creation and edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Show which distribution account funded a disbursement or payment, with a source-account column and detail rows. [#569](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/569)
 - Add a Total Balance tile aggregating every distribution account, and restore the Total Disbursed historical metric. [#569](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/569)
 - Let owners add, archive, and manage member access on distribution accounts without platform-operator intervention. [#569](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/569)
+- Add distribution-account scoping when creating or editing API-key [#571](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/571)
 
 ### Changed
 

--- a/src/api/updateApiKey.ts
+++ b/src/api/updateApiKey.ts
@@ -1,10 +1,12 @@
 import { API_URL } from "@/constants/envVariables";
 import { SESSION_EXPIRED } from "@/constants/settings";
+
 import { getSdpTenantName } from "@/helpers/getSdpTenantName";
 
 export interface UpdateApiKeyRequest {
   permissions: string[];
   allowed_ips?: string[] | null;
+  distribution_wallet_ids?: string[];
 }
 
 export const updateApiKey = async (

--- a/src/apiQueries/useDistributionWallets.ts
+++ b/src/apiQueries/useDistributionWallets.ts
@@ -11,7 +11,7 @@ export type DistributionWallet = {
   name: string;
   description?: string;
   distribution_account_address?: string | null;
-  status: "ACTIVE" | "ARCHIVED";
+  status: "ACTIVE" | "ARCHIVED" | "PENDING";
   is_default: boolean;
 };
 

--- a/src/components/ApiKeyCreateModal/ApiKeyCreateModal.tsx
+++ b/src/components/ApiKeyCreateModal/ApiKeyCreateModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { Button, Input, Modal, Notification } from "@stellar/design-system";
 
@@ -13,7 +13,6 @@ import { useDistributionWallets } from "@/apiQueries/useDistributionWallets";
 import { parseAllowedIPs } from "@/helpers/parseIPs";
 
 import { useApiKeyForm } from "@/hooks/useApiKeyForm";
-import { usePrevious } from "@/hooks/usePrevious";
 
 import { AppError, CreateApiKeyRequest } from "@/types";
 
@@ -54,19 +53,19 @@ export const CreateApiKeyModal: React.FC<CreateApiKeyModalProps> = ({
   } = useApiKeyForm({ onResetQuery, appError });
 
   const { data: distributionWallets } = useDistributionWallets(visible);
+  const hasPreselected = useRef(false);
 
-  const previousVisible = usePrevious(visible);
-
-  // Opening the form pre-selects every account the creator can reach, matching what the API grants
-  // a key that names none. Narrowing from there is the point of the picker.
+  // Pre-selects every account the creator can reach, once, whenever the list arrives — the modal
+  // remounts on each open, so the ref starts false again with it.
   useEffect(() => {
-    if (visible && !previousVisible && distributionWallets) {
+    if (!hasPreselected.current && distributionWallets) {
+      hasPreselected.current = true;
       setFormData((prev) => ({
         ...prev,
         distributionWalletIds: distributionWallets.map((wallet) => wallet.id),
       }));
     }
-  }, [visible, previousVisible, distributionWallets, setFormData]);
+  }, [distributionWallets, setFormData]);
 
   const handleClose = () => {
     onClose();

--- a/src/components/ApiKeyCreateModal/ApiKeyCreateModal.tsx
+++ b/src/components/ApiKeyCreateModal/ApiKeyCreateModal.tsx
@@ -1,16 +1,19 @@
 import { useEffect, useState } from "react";
+
 import { Button, Input, Modal, Notification } from "@stellar/design-system";
 
-import { ErrorWithExtras } from "@/components/ErrorWithExtras";
 import {
   ApiKeyFormFields,
   convertToApiPermissions,
 } from "@/components/ApiKeyFormFields/ApiKeyFormFields";
+import { ErrorWithExtras } from "@/components/ErrorWithExtras";
+
+import { useDistributionWallets } from "@/apiQueries/useDistributionWallets";
+
+import { parseAllowedIPs } from "@/helpers/parseIPs";
 
 import { useApiKeyForm } from "@/hooks/useApiKeyForm";
 import { usePrevious } from "@/hooks/usePrevious";
-
-import { parseAllowedIPs } from "@/helpers/parseIPs";
 
 import { AppError, CreateApiKeyRequest } from "@/types";
 
@@ -39,26 +42,31 @@ export const CreateApiKeyModal: React.FC<CreateApiKeyModalProps> = ({
 
   const {
     formData,
+    setFormData,
     handleAllowedIPsChange,
     handlePermissionChange,
     handleAllowedIPsBlur,
+    handleWalletToggle,
     validatePermissions,
     getAllowedIPsError,
     getPermissionsError,
     isFormValid,
-    resetForm,
   } = useApiKeyForm({ onResetQuery, appError });
+
+  const { data: distributionWallets } = useDistributionWallets(visible);
 
   const previousVisible = usePrevious(visible);
 
+  // Opening the form pre-selects every account the creator can reach, matching what the API grants
+  // a key that names none. Narrowing from there is the point of the picker.
   useEffect(() => {
-    if (previousVisible && !visible) {
-      setName("");
-      setExpiryDate("");
-      setNameError(false);
-      resetForm();
+    if (visible && !previousVisible && distributionWallets) {
+      setFormData((prev) => ({
+        ...prev,
+        distributionWalletIds: distributionWallets.map((wallet) => wallet.id),
+      }));
     }
-  }, [visible, previousVisible, resetForm]);
+  }, [visible, previousVisible, distributionWallets, setFormData]);
 
   const handleClose = () => {
     onClose();
@@ -105,6 +113,7 @@ export const CreateApiKeyModal: React.FC<CreateApiKeyModalProps> = ({
       permissions: apiPermissions,
       expiry_date: expiryDate ? new Date(expiryDate).toISOString() : undefined,
       allowed_ips: allowedIPs.length > 0 ? allowedIPs : undefined,
+      distribution_wallet_ids: formData.distributionWalletIds,
     };
 
     onSubmit(apiKeyData);
@@ -159,6 +168,9 @@ export const CreateApiKeyModal: React.FC<CreateApiKeyModalProps> = ({
               onPermissionChange={handlePermissionChange}
               allowedIPsError={getAllowedIPsError()}
               permissionsError={getPermissionsError()}
+              distributionWallets={distributionWallets}
+              selectedWalletIds={formData.distributionWalletIds}
+              onWalletToggle={handleWalletToggle}
             />
           </div>
         </Modal.Body>

--- a/src/components/ApiKeyDetails/ApiKeyDetails.tsx
+++ b/src/components/ApiKeyDetails/ApiKeyDetails.tsx
@@ -1,30 +1,41 @@
 import { useEffect, useState, useCallback } from "react";
-import { useNavigate, useParams } from "react-router-dom";
-import { Button, Card, Heading, Icon, Notification } from "@stellar/design-system";
-import { useDispatch } from "react-redux";
 
-import { getApiKey } from "@/api/getApiKey";
-import { UpdateApiKeyRequest } from "@/api/updateApiKey";
+import { useDispatch } from "react-redux";
+import { useNavigate, useParams } from "react-router-dom";
+
+import { Button, Card, Heading, Icon, Notification } from "@stellar/design-system";
+
+import { DeleteApiKeyModal } from "@/components/ApiKeyDeleteModal/DeleteApiKeyModal";
+import { EditApiKeyModal } from "@/components/ApiKeyUpdateModal/EditApiKeyModal";
 import { Breadcrumbs } from "@/components/Breadcrumbs";
-import { SectionHeader } from "@/components/SectionHeader";
 import { CopyWithIcon } from "@/components/CopyWithIcon";
 import { ErrorWithExtras } from "@/components/ErrorWithExtras";
+import { SectionHeader } from "@/components/SectionHeader";
 import { ShowForRoles } from "@/components/ShowForRoles";
-import { EditApiKeyModal } from "@/components/ApiKeyUpdateModal/EditApiKeyModal";
-import { DeleteApiKeyModal } from "@/components/ApiKeyDeleteModal/DeleteApiKeyModal";
 import { ValuesList } from "@/components/ValueList/ValueList";
-import { API_KEY_PERMISSION_RESOURCES } from "@/constants/apiKeyPermissions";
-import { Routes } from "@/constants/settings";
-import { formatDateTime } from "@/helpers/formatIntlDateTime";
-import { normalizeApiError } from "@/helpers/normalizeApiError";
-import { useRedux } from "@/hooks/useRedux";
-import { AppDispatch } from "@/store";
+
 import {
   deleteApiKeyAction,
   updateApiKeyAction,
   clearApiKeysErrorAction,
 } from "@/store/ducks/apiKeys";
+
+import { API_KEY_PERMISSION_RESOURCES } from "@/constants/apiKeyPermissions";
+import { Routes } from "@/constants/settings";
+
+import { getApiKey } from "@/api/getApiKey";
+import { UpdateApiKeyRequest } from "@/api/updateApiKey";
+
+import { useDistributionWallets } from "@/apiQueries/useDistributionWallets";
+
+import { formatDateTime } from "@/helpers/formatIntlDateTime";
+import { normalizeApiError } from "@/helpers/normalizeApiError";
+
+import { useRedux } from "@/hooks/useRedux";
+
 import { ApiKey, UserRole, ApiError, AppError } from "@/types";
+
+import { AppDispatch } from "@/store";
 
 import "./styles.scss";
 
@@ -35,6 +46,7 @@ export const ApiKeyDetails = () => {
   const navigate = useNavigate();
   const dispatch: AppDispatch = useDispatch();
   const { apiKeys, userAccount } = useRedux("apiKeys", "userAccount");
+  const { data: allWallets } = useDistributionWallets(Boolean(userAccount.isAuthenticated), true);
 
   const [apiKey, setApiKey] = useState<ApiKey | undefined>();
   const [isLoading, setIsLoading] = useState(true);
@@ -122,6 +134,18 @@ export const ApiKeyDetails = () => {
 
     const isExpired = new Date() > new Date(apiKey.expiry_date);
     return isExpired ? "EXPIRED" : "ACTIVE";
+  };
+
+  const formatWalletScope = (walletIds: string[]): string[] => {
+    return (walletIds ?? []).map((walletId) => {
+      const wallet = allWallets?.find((w) => w.id === walletId);
+
+      if (!wallet) {
+        return walletId;
+      }
+
+      return wallet.status === "ARCHIVED" ? `${wallet.name} (archived)` : wallet.name;
+    });
   };
 
   const formatPermissions = (permissions: string[]): string[] => {
@@ -275,6 +299,28 @@ export const ApiKeyDetails = () => {
                 <ValuesList
                   values={formatPermissions(apiKey.permissions)}
                   emptyMessage="No permissions assigned"
+                />
+              </div>
+            </div>
+          </Card>
+        </div>
+
+        <div className="DetailsSection DetailsSection">
+          <SectionHeader>
+            <SectionHeader.Row>
+              <SectionHeader.Content>
+                <Heading as="h4" size="xs">
+                  Distribution Accounts
+                </Heading>
+              </SectionHeader.Content>
+            </SectionHeader.Row>
+          </SectionHeader>
+          <Card noPadding>
+            <div className="StatCards__card">
+              <div className="ApiKeyDetails__permissions">
+                <ValuesList
+                  values={formatWalletScope(apiKey.distribution_wallet_ids)}
+                  emptyMessage="No distribution accounts (cannot send or report on funds)"
                 />
               </div>
             </div>

--- a/src/components/ApiKeyFormFields/ApiKeyFormFields.tsx
+++ b/src/components/ApiKeyFormFields/ApiKeyFormFields.tsx
@@ -1,5 +1,8 @@
-import { Heading, Select, Textarea } from "@stellar/design-system";
+import { Checkbox, Heading, Select, Textarea } from "@stellar/design-system";
+
 import { API_KEY_PERMISSION_RESOURCES } from "@/constants/apiKeyPermissions";
+
+import { DistributionWallet } from "@/apiQueries/useDistributionWallets";
 
 import "./styles.scss";
 
@@ -37,6 +40,9 @@ interface ApiKeyFormFieldsProps {
   onPermissionChange: (resource: keyof PermissionState, level: PermissionLevel) => void;
   allowedIPsError?: string;
   permissionsError?: string;
+  distributionWallets?: DistributionWallet[];
+  selectedWalletIds?: string[];
+  onWalletToggle?: (walletId: string) => void;
 }
 
 export const ApiKeyFormFields: React.FC<ApiKeyFormFieldsProps> = ({
@@ -47,8 +53,12 @@ export const ApiKeyFormFields: React.FC<ApiKeyFormFieldsProps> = ({
   onPermissionChange,
   allowedIPsError,
   permissionsError,
+  distributionWallets,
+  selectedWalletIds = [],
+  onWalletToggle,
 }) => {
   const isAllReadWrite = permissions.all === "read_write";
+  const showWallets = Boolean(onWalletToggle && distributionWallets?.length);
 
   return (
     <>
@@ -66,6 +76,31 @@ export const ApiKeyFormFields: React.FC<ApiKeyFormFieldsProps> = ({
         rows={3}
         className="ApiKeyFormFields__allowedIPs"
       />
+
+      {showWallets && (
+        <div className="ApiKeyFormFields__wallets">
+          <div className="Label__wrapper ApiKeyFormFields__walletsLabel">
+            <div className="Label Label--sm">Distribution accounts</div>
+          </div>
+
+          <div className="ApiKeyFormFields__walletsList">
+            {distributionWallets?.map((wallet) => (
+              <Checkbox
+                key={wallet.id}
+                id={`wallet-${wallet.id}`}
+                fieldSize="sm"
+                label={wallet.status === "ARCHIVED" ? `${wallet.name} (archived)` : wallet.name}
+                checked={selectedWalletIds.includes(wallet.id)}
+                onChange={() => onWalletToggle?.(wallet.id)}
+              />
+            ))}
+          </div>
+
+          <div className="FieldNote FieldNote--note FieldNote--sm ApiKeyFormFields__walletsNote">
+            This key can only send from the accounts you select, and only sees their activity.
+          </div>
+        </div>
+      )}
 
       <div className="ApiKeyFormFields__permissions">
         <Heading as="h4" size="xs" className="ApiKeyFormFields__permissionsHeading">

--- a/src/components/ApiKeyFormFields/styles.scss
+++ b/src/components/ApiKeyFormFields/styles.scss
@@ -10,6 +10,29 @@
     flex-direction: column;
   }
 
+  &__wallets {
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__walletsLabel {
+    margin-bottom: pxToRem(4px);
+  }
+
+  &__walletsNote {
+    margin-top: pxToRem(8px);
+    margin-left: 0;
+  }
+
+  &__walletsList {
+    border-top: pxToRem(1px) solid var(--sds-clr-gray-04);
+    border-bottom: pxToRem(1px) solid var(--sds-clr-gray-04);
+    display: flex;
+    flex-direction: column;
+    gap: pxToRem(12px);
+    padding: pxToRem(16px) 0;
+  }
+
   &__permissionsHeading {
     margin-bottom: pxToRem(8px);
     color: var(--sds-clr-gray-09);

--- a/src/components/ApiKeyUpdateModal/EditApiKeyModal.tsx
+++ b/src/components/ApiKeyUpdateModal/EditApiKeyModal.tsx
@@ -1,4 +1,5 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
+
 import { Button, Input, Modal, Notification } from "@stellar/design-system";
 
 import {
@@ -8,13 +9,16 @@ import {
 } from "@/components/ApiKeyFormFields/ApiKeyFormFields";
 import { ErrorWithExtras } from "@/components/ErrorWithExtras";
 
-import { useApiKeyForm } from "@/hooks/useApiKeyForm";
-import { usePrevious } from "@/hooks/usePrevious";
+import { UpdateApiKeyRequest } from "@/api/updateApiKey";
+
+import { useDistributionWallets } from "@/apiQueries/useDistributionWallets";
 
 import { formatDateTime } from "@/helpers/formatIntlDateTime";
 import { parseAllowedIPs } from "@/helpers/parseIPs";
 
-import { UpdateApiKeyRequest } from "@/api/updateApiKey";
+import { useApiKeyForm } from "@/hooks/useApiKeyForm";
+import { usePrevious } from "@/hooks/usePrevious";
+
 import { ApiKey, AppError } from "@/types";
 
 import "./styles.scss";
@@ -43,6 +47,7 @@ export const EditApiKeyModal: React.FC<EditApiKeyModalProps> = ({
     handleAllowedIPsChange,
     handlePermissionChange,
     handleAllowedIPsBlur,
+    handleWalletToggle,
     validatePermissions,
     getAllowedIPsError,
     getPermissionsError,
@@ -50,6 +55,18 @@ export const EditApiKeyModal: React.FC<EditApiKeyModalProps> = ({
     resetForm,
     setForm,
   } = useApiKeyForm({ onResetQuery, appError });
+
+  const { data: allWallets } = useDistributionWallets(visible, true);
+
+  // An account archived after this key was scoped to it stays offerable, checked, so saving an
+  // unrelated change doesn't silently drop it. Archived accounts the key doesn't hold are omitted:
+  // the API refuses to add them.
+  const selectableWallets = useMemo(() => {
+    const held = apiKey?.distribution_wallet_ids ?? [];
+    return (allWallets ?? []).filter(
+      (wallet) => wallet.status === "ACTIVE" || held.includes(wallet.id),
+    );
+  }, [allWallets, apiKey]);
 
   const previousVisible = usePrevious(visible);
 
@@ -64,6 +81,7 @@ export const EditApiKeyModal: React.FC<EditApiKeyModalProps> = ({
       setForm({
         allowedIPs: allowedIpsString,
         permissions,
+        distributionWalletIds: apiKey.distribution_wallet_ids ?? [],
       });
     } else if (previousVisible && !visible) {
       resetForm();
@@ -93,6 +111,7 @@ export const EditApiKeyModal: React.FC<EditApiKeyModalProps> = ({
     const updateData: UpdateApiKeyRequest = {
       permissions: apiPermissions,
       allowed_ips: allowedIPs.length > 0 ? allowedIPs : null,
+      distribution_wallet_ids: formData.distributionWalletIds,
     };
 
     onSubmit(apiKey.id, updateData);
@@ -148,6 +167,9 @@ export const EditApiKeyModal: React.FC<EditApiKeyModalProps> = ({
                 onPermissionChange={handlePermissionChange}
                 allowedIPsError={getAllowedIPsError()}
                 permissionsError={getPermissionsError()}
+                distributionWallets={selectableWallets}
+                selectedWalletIds={formData.distributionWalletIds}
+                onWalletToggle={handleWalletToggle}
               />
             </div>
           </Modal.Body>

--- a/src/hooks/useApiKeyForm.ts
+++ b/src/hooks/useApiKeyForm.ts
@@ -1,11 +1,14 @@
 import { useCallback, useState } from "react";
+
 import {
   INITIAL_PERMISSIONS,
   PermissionLevel,
   PermissionState,
   hasAnyPermissions,
 } from "@/components/ApiKeyFormFields/ApiKeyFormFields";
+
 import { validateAllowedIPs } from "@/helpers/validateIPs";
+
 import { AppError } from "@/types";
 
 interface UseApiKeyFormProps {
@@ -16,12 +19,14 @@ interface UseApiKeyFormProps {
 export interface ApiKeyFormState {
   allowedIPs: string;
   permissions: PermissionState;
+  distributionWalletIds: string[];
 }
 
 export const useApiKeyForm = ({ onResetQuery, appError }: UseApiKeyFormProps) => {
   const [formData, setFormData] = useState<ApiKeyFormState>({
     allowedIPs: "",
     permissions: { ...INITIAL_PERMISSIONS },
+    distributionWalletIds: [],
   });
   const [formErrors, setFormErrors] = useState<string[]>([]);
 
@@ -75,6 +80,22 @@ export const useApiKeyForm = ({ onResetQuery, appError }: UseApiKeyFormProps) =>
       });
     },
     [appError, onResetQuery, removeItemFromErrors],
+  );
+
+  const handleWalletToggle = useCallback(
+    (walletId: string) => {
+      if (appError) {
+        onResetQuery();
+      }
+
+      setFormData((prev) => ({
+        ...prev,
+        distributionWalletIds: prev.distributionWalletIds.includes(walletId)
+          ? prev.distributionWalletIds.filter((id) => id !== walletId)
+          : [...prev.distributionWalletIds, walletId],
+      }));
+    },
+    [appError, onResetQuery],
   );
 
   const handleAllowedIPsBlur = useCallback(() => {
@@ -132,6 +153,7 @@ export const useApiKeyForm = ({ onResetQuery, appError }: UseApiKeyFormProps) =>
     setFormData({
       allowedIPs: "",
       permissions: { ...INITIAL_PERMISSIONS },
+      distributionWalletIds: [],
     });
     setFormErrors([]);
   }, []);
@@ -148,6 +170,7 @@ export const useApiKeyForm = ({ onResetQuery, appError }: UseApiKeyFormProps) =>
     handleAllowedIPsChange,
     handlePermissionChange,
     handleAllowedIPsBlur,
+    handleWalletToggle,
     validatePermissions,
     getAllowedIPsError,
     getPermissionsError,

--- a/src/pages/ApiKeys.tsx
+++ b/src/pages/ApiKeys.tsx
@@ -35,6 +35,7 @@ export const ApiKeys = () => {
   const [isDeleteModalVisible, setIsDeleteModalVisible] = useState(false);
   const [isEditModalVisible, setIsEditModalVisible] = useState(false);
   const [createdApiKey, setCreatedApiKey] = useState<{ name: string; key: string } | undefined>();
+  const [createModalKey, setCreateModalKey] = useState(0);
   const [selectedApiKey, setSelectedApiKey] = useState<ApiKey | undefined>();
   const [editingApiKey, setEditingApiKey] = useState<ApiKey | undefined>();
 
@@ -43,6 +44,7 @@ export const ApiKeys = () => {
   }, [dispatch]);
 
   const handleCreateApiKey = useCallback(() => {
+    setCreateModalKey((k) => k + 1);
     setIsCreateModalVisible(true);
   }, []);
 
@@ -173,6 +175,7 @@ export const ApiKeys = () => {
 
       {/* Modals - rendered once outside of conditional logic */}
       <CreateApiKeyModal
+        key={createModalKey}
         visible={isCreateModalVisible}
         onClose={handleCloseCreateModal}
         onSubmit={handleSubmitCreateApiKey}

--- a/src/store/ducks/apiKeys.ts
+++ b/src/store/ducks/apiKeys.ts
@@ -1,15 +1,17 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
-import { RootState } from "@/store";
 
-import { endSessionIfTokenInvalid } from "@/helpers/endSessionIfTokenInvalid";
-import { refreshSessionToken } from "@/helpers/refreshSessionToken";
-import { normalizeApiError } from "@/helpers/normalizeApiError";
+import { deleteApiKey } from "@/api/deleteApiKey";
 import { getApiKeys } from "@/api/getApiKeys";
 import { postApiKey } from "@/api/postApiKey";
-import { deleteApiKey } from "@/api/deleteApiKey";
 import { updateApiKey, UpdateApiKeyRequest } from "@/api/updateApiKey";
 
+import { endSessionIfTokenInvalid } from "@/helpers/endSessionIfTokenInvalid";
+import { normalizeApiError } from "@/helpers/normalizeApiError";
+import { refreshSessionToken } from "@/helpers/refreshSessionToken";
+
 import { ApiKey, ApiKeysInitialState, ApiError, RejectMessage, CreateApiKeyRequest } from "@/types";
+
+import { RootState } from "@/store";
 
 export const apiKeysInitialState: ApiKeysInitialState = {
   items: [],
@@ -196,6 +198,10 @@ const apiKeysSlice = createSlice({
             ...state.items[index],
             permissions: updateData.permissions,
             allowed_ips: updateData.allowed_ips || [],
+            // Omitted means the API left the scope untouched, so keep what we already had.
+            ...(updateData.distribution_wallet_ids
+              ? { distribution_wallet_ids: updateData.distribution_wallet_ids }
+              : {}),
           };
         }
         state.errorString = undefined;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1042,6 +1042,7 @@ export type ApiKey = {
   updated_by: string;
   last_used_at: string | null;
   allowed_ips: string[];
+  distribution_wallet_ids: string[];
   enabled: boolean;
 };
 
@@ -1061,6 +1062,7 @@ export type CreateApiKeyRequest = {
   expiry_date?: string | null;
   permissions: string[];
   allowed_ips?: string[];
+  distribution_wallet_ids?: string[];
 };
 
 export type UpdateApiKeyRequest = {
@@ -1068,6 +1070,7 @@ export type UpdateApiKeyRequest = {
   expiry_date?: string | null;
   permissions?: string[];
   allowed_ips?: string[];
+  distribution_wallet_ids?: string[];
   enabled?: boolean;
 };
 


### PR DESCRIPTION
### What

Lets you choose which distribution accounts an API key can use, when creating or editing it.

- Checkbox picker in both modals, listing only the accounts you can reach. Creating pre-selects them all; editing starts from the key's current scope.
- An account archived after the key was scoped to it still shows, marked archived, so saving an unrelated edit doesn't silently drop it.
- The key detail page shows the accounts a key is scoped to.

### Why

The backend now stores a per-key account scope, so it needs somewhere to be set. Without this the dashboard can only create keys that inherit everything their creator can reach, and there's no way to see or change what a key is scoped to.

### Known limitations

- The permissions list has no row for `read:distribution_wallets` / `write:distribution_wallets`, so those can only be granted via read:all / write:all. Opening and saving the edit modal on a key that has them will drop them, because the form's permission model can't represent them. Follow-up PR.

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] Preview deployment works as expected
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Ready for production
