### PR TITLE
SDP-2117 fix: add distribution account permissions to API key modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Surface `fetchApi` errors with operator-facing messages instead of failing silently. [#569](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/569)
 - Fail loudly on session expiry instead of rendering a blank page. [#569](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/569)
 - Fix receiver invitation timestamps showing "now" instead of the actual time. [#569](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/569)
+- Add missing distribution-account permissions to API-key creation/editing modal [#572](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/572)
 
 ## [6.6.0](https://github.com/stellar/stellar-disbursement-platform-frontend/releases/tag/6.6.0) ([diff](https://github.com/stellar/stellar-disbursement-platform-frontend/compare/6.5.0...6.6.0))
 

--- a/src/components/ApiKeyFormFields/ApiKeyFormFields.tsx
+++ b/src/components/ApiKeyFormFields/ApiKeyFormFields.tsx
@@ -1,4 +1,5 @@
 import { Heading, Select, Textarea } from "@stellar/design-system";
+
 import { API_KEY_PERMISSION_RESOURCES } from "@/constants/apiKeyPermissions";
 
 import "./styles.scss";
@@ -13,6 +14,7 @@ export type PermissionState = {
   organization: PermissionLevel;
   users: PermissionLevel;
   wallets: PermissionLevel;
+  distribution_wallets: PermissionLevel;
   statistics: PermissionLevel;
   exports: PermissionLevel;
 };
@@ -25,6 +27,7 @@ export const INITIAL_PERMISSIONS: PermissionState = {
   organization: "none",
   users: "none",
   wallets: "none",
+  distribution_wallets: "none",
   statistics: "none",
   exports: "none",
 };
@@ -181,6 +184,7 @@ export const parseExistingPermissions = (permissions: string[]): PermissionState
     organization: "organization",
     users: "users",
     wallets: "wallets",
+    distribution_wallets: "distribution_wallets",
     statistics: "statistics",
     exports: "exports",
   };

--- a/src/constants/apiKeyPermissions.ts
+++ b/src/constants/apiKeyPermissions.ts
@@ -11,6 +11,7 @@ export const API_KEY_PERMISSION_RESOURCES: PermissionResource[] = [
   { key: "organization", label: "Organization", hasWrite: true },
   { key: "users", label: "Users", hasWrite: true },
   { key: "wallets", label: "Wallets", hasWrite: true },
+  { key: "distribution_wallets", label: "Distribution accounts", hasWrite: true },
   { key: "statistics", label: "Statistics", hasWrite: false },
   { key: "exports", label: "Exports", hasWrite: false },
 ] as const;


### PR DESCRIPTION
### What

Adds a Distribution accounts row to the permissions list in the API key create and edit modals, granting `read:distribution_wallets` / `write:distribution_wallets`.

### Why

The backend added these two permissions with multi-wallet (#1178), but the modal was never updated, so they could only be granted via the blunt `read:all` / `write:all`.

It also fixes a silent data loss: because `parseExistingPermissions` had no entry for them, a key created through the API with `write:distribution_wallets` displayed as None in the edit modal, and saving that form wrote the parsed state back, dropping the permission without telling anyone.

### Known limitations

- In accordance with the original design of multi-wallet (#1178), granting these permissions doesn't guarantee the key can use every distribution-wallet endpoint. The Owner-only ones (create, archive, promote, grant/revoke, memberships, audit) also require the key's creator to be an Owner, so a developer-minted key with `write:distribution_wallets` still gets 403 there.

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] Preview deployment works as expected
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Ready for production
