### PR TITLE
SDP-2116 fix: harden receiver scoping per distribution account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Surface `fetchApi` errors with operator-facing messages instead of failing silently. [#569](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/569)
 - Fail loudly on session expiry instead of rendering a blank page. [#569](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/569)
 - Fix receiver invitation timestamps showing "now" instead of the actual time. [#569](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/569)
+- Fix distribution-account scoping on per-receiver payment counters. [#573](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/573)
 
 ## [6.6.0](https://github.com/stellar/stellar-disbursement-platform-frontend/releases/tag/6.6.0) ([diff](https://github.com/stellar/stellar-disbursement-platform-frontend/compare/6.5.0...6.6.0))
 

--- a/src/apiQueries/useCreateReceiver.ts
+++ b/src/apiQueries/useCreateReceiver.ts
@@ -1,20 +1,30 @@
 import { useMutation } from "@tanstack/react-query";
 
 import { API_URL } from "@/constants/envVariables";
+
 import { fetchApi } from "@/helpers/fetchApi";
+
 import { ApiReceiver, AppError, CreateReceiverRequest } from "@/types";
 
 export const useCreateReceiver = ({
   onSuccess,
+  selectedWalletId,
 }: {
   onSuccess: (receiver: ApiReceiver) => void;
+  selectedWalletId?: string | null;
 }) => {
   const mutation = useMutation({
     mutationFn: (receiverData: CreateReceiverRequest) => {
-      return fetchApi(`${API_URL}/receivers`, {
-        method: "POST",
-        body: JSON.stringify(receiverData),
-      });
+      // The receiver is stamped with the account it was created under, so the write has to name one.
+      // With "all accounts" selected there is nothing to stamp and the backend answers 400.
+      return fetchApi(
+        `${API_URL}/receivers`,
+        {
+          method: "POST",
+          body: JSON.stringify(receiverData),
+        },
+        { walletId: selectedWalletId || null },
+      );
     },
     onSuccess,
   });

--- a/src/apiQueries/useReceiversReceiverId.ts
+++ b/src/apiQueries/useReceiversReceiverId.ts
@@ -5,6 +5,9 @@ import { API_URL } from "@/constants/envVariables";
 import { fetchApi } from "@/helpers/fetchApi";
 import { formatPaymentReceiver } from "@/helpers/formatPaymentReceiver";
 import { formatReceiver } from "@/helpers/formatReceiver";
+import { ALL_ACCOUNTS } from "@/helpers/localStorageSelectedWallet";
+
+import { useSelectedWallet } from "@/hooks/useSelectedWallet";
 
 import { ApiReceiver, AppError, PaymentDetailsReceiver, ReceiverDetails } from "@/types";
 
@@ -17,10 +20,17 @@ export const useReceiversReceiverId = <T>({
   dataFormat: "receiver" | "paymentReceiver" | "raw";
   receiverWalletId?: string;
 }) => {
+  const { selectedWalletId } = useSelectedWallet();
+  // The response carries payment counters scoped to the selected account, so the cache entry is
+  // keyed by the same account that produced its X-Wallet-Id header.
+  const walletKey = selectedWalletId || ALL_ACCOUNTS;
+
   const query = useQuery<ApiReceiver | ReceiverDetails | PaymentDetailsReceiver, AppError>({
-    queryKey: ["receivers", dataFormat, receiverId, { receiverWalletId }],
+    queryKey: ["receivers", dataFormat, receiverId, { receiverWalletId, walletKey }],
     queryFn: async () => {
-      const response = await fetchApi(`${API_URL}/receivers/${receiverId}`);
+      const response = await fetchApi(`${API_URL}/receivers/${receiverId}`, undefined, {
+        walletId: selectedWalletId || null,
+      });
       if (dataFormat === "raw") {
         return response;
       }

--- a/src/pages/Receivers.tsx
+++ b/src/pages/Receivers.tsx
@@ -1,11 +1,11 @@
-import { Button, Heading, Icon, Input, Notification, Select } from "@stellar/design-system";
-import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
+
+import { useQueryClient } from "@tanstack/react-query";
 import { useDispatch } from "react-redux";
 import { useNavigate } from "react-router-dom";
 
-import { AppDispatch } from "@/store";
-import { exportDataAction } from "@/store/ducks/dataExport";
+import { Button, Heading, Icon, Input, Notification, Select } from "@stellar/design-system";
+
 
 import { ErrorWithExtras } from "@/components/ErrorWithExtras";
 import { FilterMenu } from "@/components/FilterMenu";
@@ -15,11 +15,17 @@ import { ReceiversTable } from "@/components/ReceiversTable";
 import { SearchInput } from "@/components/SearchInput";
 import { SectionHeader } from "@/components/SectionHeader";
 
+import { exportDataAction } from "@/store/ducks/dataExport";
+
+import { PAGE_LIMIT_OPTIONS, Routes } from "@/constants/settings";
+
 import { useCreateReceiver } from "@/apiQueries/useCreateReceiver";
 import { useReceivers } from "@/apiQueries/useReceivers";
-import { PAGE_LIMIT_OPTIONS, Routes } from "@/constants/settings";
+
 import { number } from "@/helpers/formatIntlNumber";
+
 import { useSelectedWallet } from "@/hooks/useSelectedWallet";
+
 import {
   CommonFilters,
   CreateReceiverRequest,
@@ -27,6 +33,8 @@ import {
   SortDirection,
   SortParams,
 } from "@/types";
+
+import { AppDispatch } from "@/store";
 
 export const Receivers = () => {
   const [currentPage, setCurrentPage] = useState(1);
@@ -75,6 +83,7 @@ export const Receivers = () => {
       setIsReceiverCreateModalVisible(false);
       queryClient.invalidateQueries({ queryKey: ["receivers"] });
     },
+    selectedWalletId,
   });
 
   const isFiltersSelected = Object.values(filters).filter((v) => Boolean(v)).length > 0;


### PR DESCRIPTION
### What

This is the corresponding frontend implementation of [backend PR 1186](https://github.com/stellar/stellar-disbursement-platform-backend/pull/1186). It fixes distribution-account scoping on receiver reads for per-receiver payment counters and csv exports.
- Send `X-Wallet-Id` when creating a receiver (`useCreateReceiver`), taken from the account switcher.
- Send `X-Wallet-Id` when fetching receiver details (`useReceiversReceiverId`), and include the account in the React Query key.

### Why

- The backend now stamps each receiver with the account it was created under, so the create request has to name one. Without this, creating a receiver fails with a `400` on any tenant with more than one distribution account.
- The stat cards on the receiver details page were counting every account's payments while the table below them was scoped to the selected account. The backend can only scope the counters if the request says which account is selected.
- The account belongs in the query key because the response now varies by account, otherwise switching accounts serves the previous one's cached numbers.

### Known limitations

- With All accounts selected there is no account to stamp, so creating a receiver returns `400`. The error is rewritten to `"Select a distribution account first — pick one in the account switcher at the top of the page.`" The button stays enabled, so the user finds out on submit rather than before. Users with a single account are unaffected; the switcher pins them.

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] Preview deployment works as expected
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Ready for production
