### PR TITLE
SDP-2122 fix: expose circle transaction ID for both payouts and transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix receiver invitation timestamps showing "now" instead of the actual time. [#569](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/569)
 - Add missing distribution-account permissions to API-key creation/editing modal [#572](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/572)
 - Fix distribution-account scoping on per-receiver payment counters. [#573](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/573)
-- Expose Circle transaction ID for payments made through both Payouts API (previously returned `null`)[#575](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/575)
+- Expose Circle transaction ID for payments made through both Payouts (previously returned `null`) and Transfers API. [#575](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/575)
 
 ## [6.6.0](https://github.com/stellar/stellar-disbursement-platform-frontend/releases/tag/6.6.0) ([diff](https://github.com/stellar/stellar-disbursement-platform-frontend/compare/6.5.0...6.6.0))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix receiver invitation timestamps showing "now" instead of the actual time. [#569](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/569)
 - Add missing distribution-account permissions to API-key creation/editing modal [#572](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/572)
 - Fix distribution-account scoping on per-receiver payment counters. [#573](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/573)
+- Expose Circle transaction ID for payments made through both Payouts API (previously returned `null`)[#575](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/575)
 
 ## [6.6.0](https://github.com/stellar/stellar-disbursement-platform-frontend/releases/tag/6.6.0) ([diff](https://github.com/stellar/stellar-disbursement-platform-frontend/compare/6.5.0...6.6.0))
 

--- a/src/helpers/formatPaymentDetails.ts
+++ b/src/helpers/formatPaymentDetails.ts
@@ -13,7 +13,8 @@ export const formatPaymentDetails = (payment: ApiPayment): PaymentDetails => {
     totalAmount: payment.amount,
     assetCode: payment.asset.code,
     externalPaymentId: payment?.external_payment_id,
-    circleTransferRequestId: payment?.circle_transfer_request_id,
+    circleTransactionId: payment?.circle_transaction_id,
+    circleTransactionType: payment?.circle_transaction_type,
     sourceWalletId: payment.source_wallet_id,
     status: payment.status,
     statusHistory: payment?.status_history

--- a/src/pages/PaymentDetails.tsx
+++ b/src/pages/PaymentDetails.tsx
@@ -261,10 +261,14 @@ export const PaymentDetails = () => {
                     </div>
                   </div>
 
-                  {formattedPayment.circleTransferRequestId ? (
+                  {formattedPayment.circleTransactionId ? (
                     <div className="PaymentDetails__info">
-                      <label className="Label">Circle Transfer ID</label>
-                      <div>{formattedPayment.circleTransferRequestId}</div>
+                      <label className="Label">
+                        {formattedPayment.circleTransactionType === "PAYOUT"
+                          ? "Circle Payout ID"
+                          : "Circle Transfer ID"}
+                      </label>
+                      <div>{formattedPayment.circleTransactionId}</div>
                     </div>
                   ) : null}
                 </div>

--- a/src/pages/PaymentDetails.tsx
+++ b/src/pages/PaymentDetails.tsx
@@ -39,7 +39,14 @@ import {
 } from "@/helpers/receiverContactInfo";
 import { shortenString } from "@/helpers/shortenString";
 
-import { PaymentDetailsReceiver } from "@/types";
+import { CircleTransactionType, PaymentDetailsReceiver } from "@/types";
+
+// Falls back to the neutral label when the type is absent or unrecognised.
+const CIRCLE_ID_LABELS: Partial<Record<CircleTransactionType, string>> = {
+  PAYOUT: "Circle Payout ID",
+  TRANSFER: "Circle Transfer ID",
+};
+const CIRCLE_ID_LABEL_FALLBACK = "Circle Transaction ID";
 
 // TODO: handle loading/fetching state (create component that handles it
 // everywhere)
@@ -264,9 +271,9 @@ export const PaymentDetails = () => {
                   {formattedPayment.circleTransactionId ? (
                     <div className="PaymentDetails__info">
                       <label className="Label">
-                        {formattedPayment.circleTransactionType === "PAYOUT"
-                          ? "Circle Payout ID"
-                          : "Circle Transfer ID"}
+                        {(formattedPayment.circleTransactionType &&
+                          CIRCLE_ID_LABELS[formattedPayment.circleTransactionType]) ||
+                          CIRCLE_ID_LABEL_FALLBACK}
                       </label>
                       <div>{formattedPayment.circleTransactionId}</div>
                     </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -346,6 +346,9 @@ export type PaymentStatus =
   | "FAILED"
   | "CANCELED";
 
+// Which Circle API produced a payment's identifier.
+export type CircleTransactionType = "PAYOUT" | "TRANSFER";
+
 export type PaymentsSearchParams = CommonFilters &
   SortParams &
   PaginationParams & { receiver_id?: string };
@@ -383,7 +386,8 @@ export type PaymentDetails = {
   status: PaymentStatus;
   statusHistory: PaymentDetailsStatusHistoryItem[];
   externalPaymentId?: string;
-  circleTransferRequestId?: string;
+  circleTransactionId?: string;
+  circleTransactionType?: CircleTransactionType;
   // Distribution wallet the funds leave from; empty/absent on pre-migration rows.
   sourceWalletId?: string;
 };
@@ -733,7 +737,8 @@ export type ApiPayment = {
   created_at: string;
   updated_at: string;
   external_payment_id?: string;
-  circle_transfer_request_id?: string;
+  circle_transaction_id?: string;
+  circle_transaction_type?: CircleTransactionType;
   // Distribution wallet the funds leave from; empty/absent on pre-migration rows.
   source_wallet_id?: string;
 };


### PR DESCRIPTION
### What

Renames the Circle identifier field on the payment API type and surfaces it correctly for both Circle APIs.

- `src/types/index.ts` - new `CircleTransactionType = "PAYOUT" | "TRANSFER"`. On `ApiPayment`, `circle_transfer_request_id` is now `circle_transaction_id`, plus new `circle_transaction_type`. Same rename on the UI-facing `PaymentDetails` type.
- `src/helpers/formatPaymentDetails.ts` - maps both fields through.
- `src/pages/PaymentDetails.tsx` - reads the renamed field, and the label is now derived from the type: "Circle Payout ID" or "Circle Transfer ID" instead of always saying "Transfer".

One row on one page changes: Payment Details (`/payments/:id`), directly under External Payment ID.

### Why

The backend field was added when Transfers was Circle's only API. When the Payouts API landed, the data layer was extended but the presentation layer wasn't, so `circle_transfer_request_id` stayed null for every Payouts-API tenant, and the Payment Details row simply never rendered for them.

The backend now returns whichever ID applies under a neutral name, with a type discriminator; this is the client half of that change. Without it, the panel would go blank for all Circle tenants once the backend ships, including the Transfers tenants who can see it today.

### Known limitations

- Still one payment at a time. The ID appears only on the details page, not in the payments list, and not in the frontend at al for bulk work. Anyone reconciling a month of payments still needs the backend CSV export, which carries `CircleTransactionID` / `CircleTransactionType` as separate columns. This PR doesn't help at volume.

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] Preview deployment works as expected
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Ready for production
