### PR TITLE
SDP-2128 fix: left-align Total Disbursed column in DashboardAnalytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Left-align Total Disbursed column in DashboardAnalytics. [#581](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/581)
+
 ## [7.0.0](https://github.com/stellar/stellar-disbursement-platform-frontend/releases/tag/7.0.0) ([diff](https://github.com/stellar/stellar-disbursement-platform-frontend/compare/6.6.0...7.0.0))
 
 ### Added

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -201,7 +201,7 @@ body {
         flex-shrink: 0;
       }
 
-      & > div:nth-child(2) {
+      & > div:nth-child(2):last-child {
         text-align: right;
       }
     }


### PR DESCRIPTION
### What

- Add condition to `DashboardAnalytics` styling that right-aligns a column only if the column is both the second _and_ last.
   - Effectively: left-align the 'Total Disbursed' column in the Analytics page.
   
Before:
<img width="1055" height="477" alt="image" src="https://github.com/user-attachments/assets/52136cfc-e6a4-4960-952c-bda0af2fddee" />

After:
<img width="1041" height="450" alt="image" src="https://github.com/user-attachments/assets/992eeb53-4a63-4ebf-b1b8-596983d13995" />


### Why

The `DashboardAnalytics` table component is reused across Home and Analytics pages. Previously, any second column in the table was right-aligned, whatever the column count. SDP 7.0.0 introduced a third column to the component in the Analytics page, causing the second column (Total Disbursed) to appear oddly right-aligned.

### Known limitations

N/A

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] Preview deployment works as expected
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Ready for production
