### PR TITLE
SDP-2137 chore: add DistributionAccountLabel to WalletBalancesOverview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Add distribution account label to WalletBalancesOverview. [#582](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/582)
+
 ### Changed
 
 - Consolidate distribution account labels into shared component. [#583](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/583)

--- a/src/components/WalletBalancesOverview.tsx
+++ b/src/components/WalletBalancesOverview.tsx
@@ -5,6 +5,7 @@ import { Button, Card, Notification } from "@stellar/design-system";
 import { AddDistributionWalletModal } from "@/components/AddDistributionWalletModal";
 import { ArchiveDistributionWalletModal } from "@/components/ArchiveDistributionWalletModal";
 import { AssetAmount } from "@/components/AssetAmount";
+import { DistributionAccountLabel } from "@/components/DistributionAccountLabel";
 import { InfoTooltip } from "@/components/InfoTooltip";
 import { ManageWalletAccessModal } from "@/components/ManageWalletAccessModal";
 import { ShowForRoles } from "@/components/ShowForRoles";
@@ -12,7 +13,6 @@ import { ShowForRoles } from "@/components/ShowForRoles";
 import { useDistributionWalletBalance } from "@/apiQueries/useDistributionWalletBalance";
 import { useDistributionWallets } from "@/apiQueries/useDistributionWallets";
 
-import { distributionAccountDisplayName } from "@/helpers/distributionAccountDisplayName";
 import { parseAssetKey } from "@/helpers/parseAssetKey";
 
 import { useIsUserRoleAccepted } from "@/hooks/useIsUserRoleAccepted";
@@ -55,7 +55,10 @@ const WalletBalanceRow = ({
       }}
     >
       <div style={{ fontWeight: 500 }}>
-        {distributionAccountDisplayName({ name, is_default: isDefault })}
+        <DistributionAccountLabel
+          wallet={{ id: walletId, name, is_default: isDefault }}
+          defaultMarker="badge"
+        />
       </div>
       <div style={{ display: "flex", gap: "1rem", alignItems: "center", flexWrap: "wrap" }}>
         <div style={{ display: "flex", gap: "1rem", flexWrap: "wrap", justifyContent: "flex-end" }}>


### PR DESCRIPTION
### What

Cosmetic enhancement: distribution account label (which includes color coded dot and DEFAULT badge) added to the `WalletBalancesOverview` Home component. This restores consistency with the distribution account color coding applied in the account switcher and across various tables in the dashboard.

Before: 
<img width="1514" height="266" alt="Before" src="https://github.com/user-attachments/assets/dfbf54c9-7064-46c8-ab9b-7bcbe5920c11" />

After: 
<img width="1516" height="242" alt="image" src="https://github.com/user-attachments/assets/6efa416b-2f6c-4a56-a134-c18f83e0d86d" />


### Why

The switcher already gives every account a stable color and a `DEFAULT` badge, but the Home overview listed accounts as plain names. Users had to read the name to match a row to the account they'd selected. This makes the two surfaces read the same way.

### Known limitations

- Two other places still render the default marker as literal `(default)` text: the single-account bar (`ActiveWalletBar/index.tsx`) and the account picker in the disbursement wizard (`DisbursementsNew.tsx`).

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] Preview deployment works as expected
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Ready for production
