### PR TITLE
SDP-2138 refactor: consolidate distribution account labels into shared component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Consolidate distribution account labels into shared component. [#583](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/583)
+
 ## [7.0.0](https://github.com/stellar/stellar-disbursement-platform-frontend/releases/tag/7.0.0) ([diff](https://github.com/stellar/stellar-disbursement-platform-frontend/compare/6.6.0...7.0.0))
 
 ### Added

--- a/src/components/ActiveWalletBar/index.tsx
+++ b/src/components/ActiveWalletBar/index.tsx
@@ -3,11 +3,11 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Floater, Icon } from "@stellar/design-system";
 
 import { AssetAmount } from "@/components/AssetAmount";
+import { DistributionAccountLabel } from "@/components/DistributionAccountLabel";
 
 import { useDistributionWalletBalance } from "@/apiQueries/useDistributionWalletBalance";
 import { useDistributionWallets } from "@/apiQueries/useDistributionWallets";
 
-import { accountColor } from "@/helpers/accountColor";
 import { parseAssetKey } from "@/helpers/parseAssetKey";
 
 import { useRedux } from "@/hooks/useRedux";
@@ -246,13 +246,7 @@ export const ActiveWalletBar = () => {
           <span className="ActiveWalletBar__labelStack">
             <span className="ActiveWalletBar__label">Distribution account</span>
             <span className="ActiveWalletBar__value">
-              <span
-                className="ActiveWalletBar__dot"
-                style={{ backgroundColor: accountColor(only.id) }}
-                aria-hidden="true"
-              />
-              {only.name}
-              {only.is_default ? " (default)" : ""}
+              <DistributionAccountLabel wallet={only} defaultMarker="text" />
             </span>
           </span>
         </div>
@@ -262,9 +256,6 @@ export const ActiveWalletBar = () => {
 
   const selectedWallet = wallets.find((w) => w.id === selectedWalletId);
   const isAllAccounts = !selectedWalletId;
-  const currentLabel = isAllAccounts
-    ? "All accounts"
-    : `${selectedWallet?.name}${selectedWallet?.is_default ? " (default)" : ""}`;
 
   const trigger = (
     <button
@@ -283,14 +274,11 @@ export const ActiveWalletBar = () => {
         <span
           className={`ActiveWalletBar__value ${isAllAccounts ? "ActiveWalletBar__value--all" : ""}`}
         >
-          {!isAllAccounts && selectedWallet ? (
-            <span
-              className="ActiveWalletBar__dot"
-              style={{ backgroundColor: accountColor(selectedWallet.id) }}
-              aria-hidden="true"
-            />
+          {selectedWallet ? (
+            <DistributionAccountLabel wallet={selectedWallet} defaultMarker="text" />
+          ) : isAllAccounts ? (
+            "All accounts"
           ) : null}
-          {currentLabel}
         </span>
       </span>
       <span className="ActiveWalletBar__chevron" aria-hidden="true">
@@ -355,15 +343,7 @@ export const ActiveWalletBar = () => {
               >
                 <span className="WalletSwitcher__main">
                   <span className="WalletSwitcher__name">
-                    <span
-                      className="WalletSwitcher__dot"
-                      style={{ backgroundColor: accountColor(wallet.id) }}
-                      aria-hidden="true"
-                    />
-                    {wallet.name}
-                    {wallet.is_default ? (
-                      <span className="WalletSwitcher__badge">default</span>
-                    ) : null}
+                    <DistributionAccountLabel wallet={wallet} defaultMarker="badge" />
                   </span>
                   {isOpen ? (
                     <RowBalance

--- a/src/components/ActiveWalletBar/styles.scss
+++ b/src/components/ActiveWalletBar/styles.scss
@@ -98,14 +98,6 @@
     }
   }
 
-  &__dot {
-    display: inline-block;
-    width: 0.5rem;
-    height: 0.5rem;
-    border-radius: 999px;
-    flex-shrink: 0;
-  }
-
   &__chevron {
     display: inline-flex;
     color: var(--sds-clr-gray-10);
@@ -176,26 +168,6 @@
     gap: 0.5rem;
     font-size: 0.875rem;
     font-weight: 600;
-    color: var(--sds-clr-gray-12);
-  }
-
-  &__dot {
-    display: inline-block;
-    width: 0.5rem;
-    height: 0.5rem;
-    border-radius: 999px;
-    flex-shrink: 0;
-  }
-
-  &__badge {
-    font-size: 0.625rem;
-    text-transform: uppercase;
-    letter-spacing: 0.03em;
-    font-weight: 700;
-    padding: 1px 6px;
-    border-radius: 999px;
-    // gray-06/gray-12 clears WCAG AA in both themes (gray-04/gray-11 fell below in light).
-    background-color: var(--sds-clr-gray-06);
     color: var(--sds-clr-gray-12);
   }
 

--- a/src/components/ActiveWalletBar/styles.scss
+++ b/src/components/ActiveWalletBar/styles.scss
@@ -85,7 +85,6 @@
   &__value {
     display: flex;
     align-items: center;
-    gap: 0.375rem;
     font-size: 0.9375rem;
     font-weight: 700;
     color: var(--sds-clr-lilac-11);
@@ -165,7 +164,6 @@
   &__name {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
     font-size: 0.875rem;
     font-weight: 600;
     color: var(--sds-clr-gray-12);

--- a/src/components/DirectPaymentCreateModal/DirectPaymentCreateModal.tsx
+++ b/src/components/DirectPaymentCreateModal/DirectPaymentCreateModal.tsx
@@ -5,6 +5,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { Button, Icon, Input, Modal, Notification, Select } from "@stellar/design-system";
 
 import { DirectPaymentConfirmation } from "@/components/DirectPaymentConfirmation/DirectPaymentConfirmation";
+import { DistributionAccountLabel } from "@/components/DistributionAccountLabel";
 import { ErrorWithExtras } from "@/components/ErrorWithExtras";
 import { SelectedReceiverInfo } from "@/components/SelectedReceiverInfo/SelectedReceiverInfo";
 
@@ -17,7 +18,7 @@ import { useReceiversReceiverId } from "@/apiQueries/useReceiversReceiverId";
 import { useSearchReceivers } from "@/apiQueries/useSearchReceivers";
 import { useWallets } from "@/apiQueries/useWallets";
 
-import { accountColor } from "@/helpers/accountColor";
+import { distributionAccountDisplayName } from "@/helpers/distributionAccountDisplayName";
 import { getEnhancedWalletErrorMessage } from "@/helpers/walletErrorMessages";
 import { isValidWalletAddress } from "@/helpers/walletValidate";
 
@@ -44,22 +45,15 @@ interface DirectPaymentCreateModalProps {
 
 // A compact "Sending from [dot] Account" banner so the source account is visible at the point
 // of committing a direct payment (single-account tenants don't need it).
-const SendingFromBanner = ({ name, color }: { name?: string; color?: string }) => {
-  if (!name) {
+const SendingFromBanner = ({ wallet }: { wallet?: DistributionWallet }) => {
+  if (!wallet) {
     return null;
   }
   return (
     <div className="DirectPaymentCreateModal__sendingFrom">
       <span className="DirectPaymentCreateModal__sendingFrom__label">Sending from</span>
       <span className="DirectPaymentCreateModal__sendingFrom__value">
-        {color ? (
-          <span
-            className="DirectPaymentCreateModal__sendingFrom__dot"
-            style={{ backgroundColor: color }}
-            aria-hidden="true"
-          />
-        ) : null}
-        {name}
+        <DistributionAccountLabel wallet={wallet} />
       </span>
     </div>
   );
@@ -546,10 +540,7 @@ export const DirectPaymentCreateModal: React.FC<DirectPaymentCreateModalProps> =
       {showConfirmation ? (
         <>
           <Modal.Body>
-            <SendingFromBanner
-              name={canChooseSource ? sourceWallet?.name : undefined}
-              color={canChooseSource && sourceWallet ? accountColor(sourceWallet.id) : undefined}
-            />
+            <SendingFromBanner wallet={canChooseSource ? sourceWallet : undefined} />
             {errorMessage && (
               <Notification variant="error" title="Error" isFilled={true}>
                 <ErrorWithExtras
@@ -616,7 +607,7 @@ export const DirectPaymentCreateModal: React.FC<DirectPaymentCreateModalProps> =
                   <option value="">Select…</option>
                   {sourceWallets?.map((wallet) => (
                     <option key={wallet.id} value={wallet.id}>
-                      {`${wallet.name}${wallet.is_default ? " (default)" : ""}`}
+                      {distributionAccountDisplayName(wallet)}
                     </option>
                   ))}
                 </Select>

--- a/src/components/DirectPaymentCreateModal/styles.scss
+++ b/src/components/DirectPaymentCreateModal/styles.scss
@@ -174,12 +174,5 @@
       font-weight: 600;
       color: var(--sds-clr-gray-12);
     }
-
-    &__dot {
-      width: pxToRem(10px);
-      height: pxToRem(10px);
-      border-radius: 50%;
-      flex-shrink: 0;
-    }
   }
 }

--- a/src/components/DistributionAccountLabel/index.tsx
+++ b/src/components/DistributionAccountLabel/index.tsx
@@ -7,10 +7,6 @@ import { distributionAccountDisplayName } from "@/helpers/distributionAccountDis
 
 import "./styles.scss";
 
-// Colour dot + name of a distribution account. `defaultMarker` renders the default account either
-// as the pill badge (switcher rows) or as literal "(default)" text; `showArchived` appends an
-// "(archived)" note for historical rows. Inline so it can sit in a heading, a table cell or a
-// button label. The colour is the only dynamic value, so it travels as a CSS custom property.
 export const DistributionAccountLabel = ({
   wallet,
   defaultMarker,

--- a/src/components/DistributionAccountLabel/index.tsx
+++ b/src/components/DistributionAccountLabel/index.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+
+import { DistributionWallet } from "@/apiQueries/useDistributionWallets";
+
+import { distributionAccountColor } from "@/helpers/distributionAccountColor";
+import { distributionAccountDisplayName } from "@/helpers/distributionAccountDisplayName";
+
+import "./styles.scss";
+
+// Colour dot + name of a distribution account. `defaultMarker` renders the default account either
+// as the pill badge (switcher rows) or as literal "(default)" text; `showArchived` appends an
+// "(archived)" note for historical rows. Inline so it can sit in a heading, a table cell or a
+// button label. The colour is the only dynamic value, so it travels as a CSS custom property.
+export const DistributionAccountLabel = ({
+  wallet,
+  defaultMarker,
+  showArchived = false,
+}: {
+  wallet: Pick<DistributionWallet, "id" | "name" | "is_default"> &
+    Partial<Pick<DistributionWallet, "status">>;
+  defaultMarker?: "badge" | "text";
+  showArchived?: boolean;
+}) => {
+  const dotStyle = {
+    "--DistributionAccountLabel-dot-color": distributionAccountColor(wallet.id),
+  } as React.CSSProperties;
+
+  return (
+    <span className="DistributionAccountLabel">
+      <span className="DistributionAccountLabel__dot" style={dotStyle} aria-hidden="true" />
+      {defaultMarker === "text" ? distributionAccountDisplayName(wallet) : wallet.name}
+      {defaultMarker === "badge" && wallet.is_default ? (
+        <span className="DistributionAccountLabel__badge">default</span>
+      ) : null}
+      {showArchived && wallet.status === "ARCHIVED" ? (
+        <span className="DistributionAccountLabel__archived Note Note--small Note--noMargin">
+          (archived)
+        </span>
+      ) : null}
+    </span>
+  );
+};

--- a/src/components/DistributionAccountLabel/index.tsx
+++ b/src/components/DistributionAccountLabel/index.tsx
@@ -24,7 +24,9 @@ export const DistributionAccountLabel = ({
   return (
     <span className="DistributionAccountLabel">
       <span className="DistributionAccountLabel__dot" style={dotStyle} aria-hidden="true" />
-      {defaultMarker === "text" ? distributionAccountDisplayName(wallet) : wallet.name}
+      <span className="DistributionAccountLabel__name">
+        {defaultMarker === "text" ? distributionAccountDisplayName(wallet) : wallet.name}
+      </span>
       {defaultMarker === "badge" && wallet.is_default ? (
         <span className="DistributionAccountLabel__badge">default</span>
       ) : null}

--- a/src/components/DistributionAccountLabel/styles.scss
+++ b/src/components/DistributionAccountLabel/styles.scss
@@ -3,10 +3,16 @@
 .DistributionAccountLabel {
   display: inline-flex;
   align-items: center;
+  min-width: 0;
+
+  &__name {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 
   &__dot {
     display: inline-block;
-    // Centers dot on the text when the parent is not a flex container (ignored in flex).
     vertical-align: middle;
     width: pxToRem(10px);
     height: pxToRem(10px);

--- a/src/components/DistributionAccountLabel/styles.scss
+++ b/src/components/DistributionAccountLabel/styles.scss
@@ -1,0 +1,35 @@
+@use "../../styles/styles-utils.scss" as *;
+
+.DistributionAccountLabel {
+  display: inline-flex;
+  align-items: center;
+
+  &__dot {
+    display: inline-block;
+    // Centers dot on the text when the parent is not a flex container (ignored in flex).
+    vertical-align: middle;
+    width: pxToRem(10px);
+    height: pxToRem(10px);
+    margin-right: var(--sds-gap-sm);
+    border-radius: pxToRem(999px);
+    flex-shrink: 0;
+    background-color: var(--DistributionAccountLabel-dot-color);
+  }
+
+  &__badge {
+    margin-left: var(--sds-gap-sm);
+    font-size: pxToRem(10px);
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    font-weight: var(--sds-fw-bold);
+    padding: pxToRem(1px) pxToRem(6px);
+    border-radius: pxToRem(999px);
+    // gray-06/gray-12 clears WCAG AA in both themes (gray-04/gray-11 fell below in light).
+    background-color: var(--sds-clr-gray-06);
+    color: var(--sds-clr-gray-12);
+  }
+
+  &__archived {
+    margin-left: var(--sds-gap-sm);
+  }
+}

--- a/src/components/DistributionAccountLabel/styles.scss
+++ b/src/components/DistributionAccountLabel/styles.scss
@@ -24,7 +24,6 @@
     font-weight: var(--sds-fw-bold);
     padding: pxToRem(1px) pxToRem(6px);
     border-radius: pxToRem(999px);
-    // gray-06/gray-12 clears WCAG AA in both themes (gray-04/gray-11 fell below in light).
     background-color: var(--sds-clr-gray-06);
     color: var(--sds-clr-gray-12);
   }

--- a/src/components/DistributionAccountStellar.tsx
+++ b/src/components/DistributionAccountStellar.tsx
@@ -17,6 +17,7 @@ import { WalletTrustlines } from "@/components/WalletTrustlines";
 
 import { STELLAR_EXPERT_URL } from "@/constants/envVariables";
 
+import { DistributionWallet } from "@/apiQueries/useDistributionWallets";
 import { useUpdateBridgeIntegration } from "@/apiQueries/useUpdateBridgeIntegration";
 
 import { useOrgAccountInfo } from "@/hooks/useOrgAccountInfo";
@@ -29,14 +30,12 @@ import { BridgeIntegrationUpdate } from "@/types";
 interface DistributionAccountStellarProps {
   // Multi-account: scope the page to a specific distribution account. Defaults to the
   // tenant's (single/default) account for unchanged single-account behavior.
-  accountName?: string;
+  account?: Pick<DistributionWallet, "id" | "name" | "is_default">;
   // `undefined` means there is no wallet record at all (legacy single-account tenant), and the
   // tenant-level fallback below is correct. `null` means a real wallet record whose Stellar
   // account isn't provisioned yet — falling back there would label this account's name with the
   // tenant default's address, balances and history.
   accountAddress?: string | null;
-  accountId?: string;
-  isDefaultAccount?: boolean;
   // Trustlines are per-account on-chain state: the rows come from this account's own Horizon
   // balances, and adding one now targets this account via X-Wallet-Id. Shown for any account
   // whose identity is unambiguous — hidden only on the "All accounts" aggregate, where there is
@@ -50,10 +49,8 @@ interface DistributionAccountStellarProps {
 }
 
 export const DistributionAccountStellar = ({
-  accountName,
+  account,
   accountAddress,
-  accountId,
-  isDefaultAccount = false,
   showTrustlines = true,
   showBridgeIntegration = true,
 }: DistributionAccountStellarProps) => {
@@ -179,13 +176,10 @@ export const DistributionAccountStellar = ({
         <SectionHeader.Row>
           <SectionHeader.Content>
             <Heading as="h2" size="sm">
-              {accountName && accountId ? (
-                <DistributionAccountLabel
-                  wallet={{ id: accountId, name: accountName, is_default: isDefaultAccount }}
-                  defaultMarker="text"
-                />
+              {account ? (
+                <DistributionAccountLabel wallet={account} defaultMarker="text" />
               ) : (
-                (accountName ?? "Distribution account")
+                "Distribution account"
               )}
             </Heading>
           </SectionHeader.Content>

--- a/src/components/DistributionAccountStellar.tsx
+++ b/src/components/DistributionAccountStellar.tsx
@@ -6,6 +6,7 @@ import { AccountBalances } from "@/components/AccountBalances";
 import { Box } from "@/components/Box";
 import { BridgeIntegrationSection } from "@/components/BridgeIntegrationSection";
 import { BridgeOptInModal } from "@/components/BridgeOptInModal";
+import { DistributionAccountLabel } from "@/components/DistributionAccountLabel";
 import { ErrorWithExtras } from "@/components/ErrorWithExtras";
 import { InfoTooltip } from "@/components/InfoTooltip";
 import { LoadingContent } from "@/components/LoadingContent";
@@ -34,7 +35,8 @@ interface DistributionAccountStellarProps {
   // account isn't provisioned yet — falling back there would label this account's name with the
   // tenant default's address, balances and history.
   accountAddress?: string | null;
-  accountColorHex?: string;
+  accountId?: string;
+  isDefaultAccount?: boolean;
   // Trustlines are per-account on-chain state: the rows come from this account's own Horizon
   // balances, and adding one now targets this account via X-Wallet-Id. Shown for any account
   // whose identity is unambiguous — hidden only on the "All accounts" aggregate, where there is
@@ -50,7 +52,8 @@ interface DistributionAccountStellarProps {
 export const DistributionAccountStellar = ({
   accountName,
   accountAddress,
-  accountColorHex,
+  accountId,
+  isDefaultAccount = false,
   showTrustlines = true,
   showBridgeIntegration = true,
 }: DistributionAccountStellarProps) => {
@@ -176,24 +179,13 @@ export const DistributionAccountStellar = ({
         <SectionHeader.Row>
           <SectionHeader.Content>
             <Heading as="h2" size="sm">
-              {accountName ? (
-                <span style={{ display: "inline-flex", alignItems: "center", gap: "0.5rem" }}>
-                  {accountColorHex ? (
-                    <span
-                      aria-hidden="true"
-                      style={{
-                        display: "inline-block",
-                        width: "0.625rem",
-                        height: "0.625rem",
-                        borderRadius: "999px",
-                        backgroundColor: accountColorHex,
-                      }}
-                    />
-                  ) : null}
-                  {accountName}
-                </span>
+              {accountName && accountId ? (
+                <DistributionAccountLabel
+                  wallet={{ id: accountId, name: accountName, is_default: isDefaultAccount }}
+                  defaultMarker="text"
+                />
               ) : (
-                "Distribution account"
+                (accountName ?? "Distribution account")
               )}
             </Heading>
           </SectionHeader.Content>

--- a/src/components/SettingsTeamMembers.tsx
+++ b/src/components/SettingsTeamMembers.tsx
@@ -1,23 +1,26 @@
 import { useEffect, useState } from "react";
+
 import { Button, Card, Icon, Modal, Notification, Select } from "@stellar/design-system";
 
-import { InfoTooltip } from "@/components/InfoTooltip";
 import { DropdownMenu } from "@/components/DropdownMenu";
-import { MoreMenuButton } from "@/components/MoreMenuButton";
-import { Table } from "@/components/Table";
-import { NewUserModal } from "@/components/NewUserModal";
-import { LoadingContent } from "@/components/LoadingContent";
-import { NotificationWithButtons } from "@/components/NotificationWithButtons";
 import { ErrorWithExtras } from "@/components/ErrorWithExtras";
+import { InfoTooltip } from "@/components/InfoTooltip";
+import { LoadingContent } from "@/components/LoadingContent";
+import { MoreMenuButton } from "@/components/MoreMenuButton";
+import { NewUserModal } from "@/components/NewUserModal";
+import { NotificationWithButtons } from "@/components/NotificationWithButtons";
+import { Table } from "@/components/Table";
 
 import { USER_ROLES_ARRAY } from "@/constants/settings";
-import { userRoleText } from "@/helpers/userRoleText";
 
-import { useUsers } from "@/apiQueries/useUsers";
-import { useUpdateUserRole } from "@/apiQueries/useUpdateUserRole";
-import { useUpdateUserStatus } from "@/apiQueries/useUpdateUserStatus";
 import { useCreateNewUser } from "@/apiQueries/useCreateNewUser";
 import { useDistributionWallets } from "@/apiQueries/useDistributionWallets";
+import { useUpdateUserRole } from "@/apiQueries/useUpdateUserRole";
+import { useUpdateUserStatus } from "@/apiQueries/useUpdateUserStatus";
+import { useUsers } from "@/apiQueries/useUsers";
+
+import { distributionAccountDisplayName } from "@/helpers/distributionAccountDisplayName";
+import { userRoleText } from "@/helpers/userRoleText";
 
 import { useRedux } from "@/hooks/useRedux";
 
@@ -78,9 +81,20 @@ export const SettingsTeamMembers = () => {
     reset: resetNewUser,
   } = useCreateNewUser();
 
+  const hideModal = () => {
+    setIsStatusModalVisible(false);
+    setIsRoleModalVisible(false);
+    setIsNewUserModalVisible(false);
+    setSelectedUser(null);
+    setNewRole(null);
+    setPendingUser(null);
+    setInviteWalletId("");
+  };
+
   useEffect(() => {
     if (isRoleSuccess || isStatusSuccess) {
       getUsers();
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       hideModal();
     }
 
@@ -110,6 +124,7 @@ export const SettingsTeamMembers = () => {
   useEffect(() => {
     if (isNewUserSuccess) {
       getUsers();
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       hideModal();
     }
 
@@ -126,16 +141,6 @@ export const SettingsTeamMembers = () => {
     }
 
     return "this user";
-  };
-
-  const hideModal = () => {
-    setIsStatusModalVisible(false);
-    setIsRoleModalVisible(false);
-    setIsNewUserModalVisible(false);
-    setSelectedUser(null);
-    setNewRole(null);
-    setPendingUser(null);
-    setInviteWalletId("");
   };
 
   // Whether this invite has an account scope to decide. Owners are tenant-wide and get no
@@ -479,7 +484,7 @@ export const SettingsTeamMembers = () => {
             <option value="">Select an account</option>
             {(distributionWallets ?? []).map((w) => (
               <option value={w.id} key={w.id}>
-                {`${w.name}${w.is_default ? " (default)" : ""}`}
+                {distributionAccountDisplayName(w)}
               </option>
             ))}
           </Select>

--- a/src/components/SourceAccount.tsx
+++ b/src/components/SourceAccount.tsx
@@ -1,6 +1,6 @@
-import { useDistributionWallets } from "@/apiQueries/useDistributionWallets";
+import { DistributionAccountLabel } from "@/components/DistributionAccountLabel";
 
-import { accountColor } from "@/helpers/accountColor";
+import { useDistributionWallets } from "@/apiQueries/useDistributionWallets";
 
 import { useRedux } from "@/hooks/useRedux";
 import { useSelectedWallet } from "@/hooks/useSelectedWallet";
@@ -41,24 +41,7 @@ export const SourceAccount = ({ sourceWalletId }: { sourceWalletId?: string }) =
     return <>-</>;
   }
 
-  return (
-    <span style={{ display: "inline-flex", alignItems: "center", gap: "0.5rem" }}>
-      <span
-        style={{
-          width: "0.625rem",
-          height: "0.625rem",
-          borderRadius: "50%",
-          flexShrink: 0,
-          backgroundColor: accountColor(wallet.id),
-        }}
-        aria-hidden="true"
-      />
-      {wallet.name}
-      {wallet.status === "ARCHIVED" ? (
-        <span className="Note Note--small Note--noMargin">(archived)</span>
-      ) : null}
-    </span>
-  );
+  return <DistributionAccountLabel wallet={wallet} showArchived />;
 };
 
 // A labeled "Source account" row for the detail pages. Renders nothing for single-account

--- a/src/components/WalletBalancesOverview.tsx
+++ b/src/components/WalletBalancesOverview.tsx
@@ -12,6 +12,7 @@ import { ShowForRoles } from "@/components/ShowForRoles";
 import { useDistributionWalletBalance } from "@/apiQueries/useDistributionWalletBalance";
 import { useDistributionWallets } from "@/apiQueries/useDistributionWallets";
 
+import { distributionAccountDisplayName } from "@/helpers/distributionAccountDisplayName";
 import { parseAssetKey } from "@/helpers/parseAssetKey";
 
 import { useIsUserRoleAccepted } from "@/hooks/useIsUserRoleAccepted";
@@ -54,8 +55,7 @@ const WalletBalanceRow = ({
       }}
     >
       <div style={{ fontWeight: 500 }}>
-        {name}
-        {isDefault ? " (default)" : ""}
+        {distributionAccountDisplayName({ name, is_default: isDefault })}
       </div>
       <div style={{ display: "flex", gap: "1rem", alignItems: "center", flexWrap: "wrap" }}>
         <div style={{ display: "flex", gap: "1rem", flexWrap: "wrap", justifyContent: "flex-end" }}>

--- a/src/helpers/distributionAccountColor.ts
+++ b/src/helpers/distributionAccountColor.ts
@@ -1,6 +1,3 @@
-// Deterministic per-account color chip (AWS account-color idea): each distribution account
-// gets a stable color so users recognize "which account" at a glance, consistently in the
-// switcher, page headings, and anywhere else an account is named.
 const ACCOUNT_COLORS = [
   "#7B61FF",
   "#0EA5E9",
@@ -12,7 +9,7 @@ const ACCOUNT_COLORS = [
   "#14B8A6",
 ];
 
-export const accountColor = (key: string) => {
+export const distributionAccountColor = (key: string) => {
   let hash = 0;
   for (let i = 0; i < key.length; i += 1) {
     hash = (hash * 31 + key.charCodeAt(i)) & 0xffffffff;

--- a/src/helpers/distributionAccountDisplayName.ts
+++ b/src/helpers/distributionAccountDisplayName.ts
@@ -1,0 +1,6 @@
+import { DistributionWallet } from "@/apiQueries/useDistributionWallets";
+
+// Plain-text account name for places that can't render the label (<option>, string props).
+export const distributionAccountDisplayName = (
+  wallet: Pick<DistributionWallet, "name" | "is_default">,
+) => (wallet.is_default ? `${wallet.name} (default)` : wallet.name);

--- a/src/pages/DisbursementsNew.tsx
+++ b/src/pages/DisbursementsNew.tsx
@@ -13,6 +13,7 @@ import { DisbursementButtons } from "@/components/DisbursementButtons";
 import { DisbursementDetails } from "@/components/DisbursementDetails";
 import { DisbursementInstructions } from "@/components/DisbursementInstructions";
 import { DisbursementInviteMessage } from "@/components/DisbursementInviteMessage";
+import { DistributionAccountLabel } from "@/components/DistributionAccountLabel";
 import { ErrorWithExtras } from "@/components/ErrorWithExtras";
 import { InfoTooltip } from "@/components/InfoTooltip";
 import { NotificationWithButtons } from "@/components/NotificationWithButtons";
@@ -33,7 +34,6 @@ import { Routes } from "@/constants/settings";
 import { useDistributionWalletBalance } from "@/apiQueries/useDistributionWalletBalance";
 import { useDistributionWallets } from "@/apiQueries/useDistributionWallets";
 
-import { accountColor } from "@/helpers/accountColor";
 import { csvTotalAmount } from "@/helpers/csvTotalAmount";
 import { parseAssetKey } from "@/helpers/parseAssetKey";
 
@@ -296,17 +296,9 @@ export const DisbursementsNew = () => {
     return (
       <div className="Note" style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
         Sending from
-        <span
-          aria-hidden="true"
-          style={{
-            display: "inline-block",
-            width: "0.5rem",
-            height: "0.5rem",
-            borderRadius: "999px",
-            backgroundColor: accountColor(selectedWallet.id),
-          }}
-        />
-        <strong>{selectedWallet.name}</strong>
+        <strong>
+          <DistributionAccountLabel wallet={selectedWallet} />
+        </strong>
         {selectedWallet.distribution_account_address ? (
           <span>
             ({selectedWallet.distribution_account_address.slice(0, 4)}…
@@ -372,19 +364,7 @@ export const DisbursementsNew = () => {
                     setSelectedWalletId(wallet.id);
                   }}
                 >
-                  <span
-                    aria-hidden="true"
-                    style={{
-                      display: "inline-block",
-                      width: "0.5rem",
-                      height: "0.5rem",
-                      borderRadius: "999px",
-                      marginRight: "0.5rem",
-                      backgroundColor: accountColor(wallet.id),
-                    }}
-                  />
-                  {wallet.name}
-                  {wallet.is_default ? " (default)" : ""}
+                  <DistributionAccountLabel wallet={wallet} defaultMarker="text" />
                 </Button>
               ))}
             </div>

--- a/src/pages/DistributionAccount.tsx
+++ b/src/pages/DistributionAccount.tsx
@@ -70,9 +70,8 @@ export const DistributionAccount = () => {
     return (
       <DistributionAccountStellar
         key={only.id}
-        accountName={only.is_default ? undefined : only.name}
+        account={only.is_default ? undefined : only}
         accountAddress={only.distribution_account_address ?? null}
-        accountId={only.is_default ? undefined : only.id}
         // Bridge is tenant-level config, so it belongs on the default account's card only —
         // unlike trustlines, which are this account's own on-chain state.
         showBridgeIntegration={only.is_default}
@@ -91,10 +90,8 @@ export const DistributionAccount = () => {
     return (
       <DistributionAccountStellar
         key={selected.id}
-        accountName={selected.name}
+        account={selected}
         accountAddress={selected.distribution_account_address ?? null}
-        accountId={selected.id}
-        isDefaultAccount={selected.is_default}
         showBridgeIntegration={selected.is_default}
       />
     );
@@ -132,10 +129,8 @@ export const DistributionAccount = () => {
         .map((w) => (
           <DistributionAccountStellar
             key={w.id}
-            accountName={w.name}
+            account={w}
             accountAddress={w.distribution_account_address ?? null}
-            accountId={w.id}
-            isDefaultAccount={w.is_default}
             showTrustlines={w.is_default}
             showBridgeIntegration={w.is_default}
           />

--- a/src/pages/DistributionAccount.tsx
+++ b/src/pages/DistributionAccount.tsx
@@ -8,8 +8,6 @@ import { SectionHeader } from "@/components/SectionHeader";
 
 import { useDistributionWallets } from "@/apiQueries/useDistributionWallets";
 
-import { accountColor } from "@/helpers/accountColor";
-
 import { useCircleAccount } from "@/hooks/useCircleAccount";
 import { useRedux } from "@/hooks/useRedux";
 import { useSelectedWallet } from "@/hooks/useSelectedWallet";
@@ -74,7 +72,7 @@ export const DistributionAccount = () => {
         key={only.id}
         accountName={only.is_default ? undefined : only.name}
         accountAddress={only.distribution_account_address ?? null}
-        accountColorHex={only.is_default ? undefined : accountColor(only.id)}
+        accountId={only.is_default ? undefined : only.id}
         // Bridge is tenant-level config, so it belongs on the default account's card only —
         // unlike trustlines, which are this account's own on-chain state.
         showBridgeIntegration={only.is_default}
@@ -93,9 +91,10 @@ export const DistributionAccount = () => {
     return (
       <DistributionAccountStellar
         key={selected.id}
-        accountName={`${selected.name}${selected.is_default ? " (default)" : ""}`}
+        accountName={selected.name}
         accountAddress={selected.distribution_account_address ?? null}
-        accountColorHex={accountColor(selected.id)}
+        accountId={selected.id}
+        isDefaultAccount={selected.is_default}
         showBridgeIntegration={selected.is_default}
       />
     );
@@ -133,9 +132,10 @@ export const DistributionAccount = () => {
         .map((w) => (
           <DistributionAccountStellar
             key={w.id}
-            accountName={`${w.name}${w.is_default ? " (default)" : ""}`}
+            accountName={w.name}
             accountAddress={w.distribution_account_address ?? null}
-            accountColorHex={accountColor(w.id)}
+            accountId={w.id}
+            isDefaultAccount={w.is_default}
             showTrustlines={w.is_default}
             showBridgeIntegration={w.is_default}
           />


### PR DESCRIPTION
### What

- Add `DistributionAccountLabel`: the single implementation of the account color dot + name, with an optional default marker (`"badge"` or `"text"`) and `(archived)` note. 
   - The color is the only dynamic value and is passed as a CSS custom property (`- DistributionAccountLabel-dot-color`), the same pattern `Box` uses.
- Replace the eight hand-rolled dot copies with it: account switcher (×3), Payments/Disbursements "Account" column (`SourceAccount`), distribution account heading, direct payment "Sending from" banner, disbursement wizard (×2). Delete their per-file dot/badge SCSS.
- Add `distributionAccountDisplayName()` for the `"Name (default)"` string used in `<option>` elements and string props.
- Rename `accountColor` to `distributionAccountColor`.
- One dot size (10px) everywhere; `develop` had 8px in the switcher/wizard and 10px elsewhere.

### Why

`develop` had nine independent implementations of the same dot with drifting sizes (0.5 vs 0.625rem), radii (`999px` vs `50%`) and spacing, and the `(default)` marker was rendered three different ways in nine places. Each new surfacewas copying one of them. One component removes the inline styles and makes the next surface a one-liner.

### Known limitations

- The palette in `distributionAccountColor.ts` is still eight hardcoded hex values; moving it to `--sds-clr-*` tokens (theme-aware, no inline style at all) is a separate PR that may need design input.
- `SettingsTeamMembers.tsx` carries a small unrelated cleanup so it can pass the pre-commit hook: `hideModal` moved above the effects that use it (pre-existing react-hooks/immutability error), the repo-standard set-state-in-effect disables on those calls, and import/order auto-fixes.

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] Preview deployment works as expected
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Ready for production
