### PR TITLE
SDP-2141 fix: make Box gap="custom" apply a gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - Left-align Total Disbursed column in DashboardAnalytics. [#581](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/581)
+- Fix the Box component's gap="custom" variant, which rendered no gap. [#586](https://github.com/stellar/stellar-disbursement-platform-frontend/pull/586)
 
 ## [7.0.0](https://github.com/stellar/stellar-disbursement-platform-frontend/releases/tag/7.0.0) ([diff](https://github.com/stellar/stellar-disbursement-platform-frontend/compare/6.6.0...7.0.0))
 

--- a/src/components/Box/index.tsx
+++ b/src/components/Box/index.tsx
@@ -26,16 +26,12 @@ export const Box = ({
     "--Box-direction": direction,
     "--Box-justify": justify,
     "--Box-align": align,
+    ...(gap === "custom" ? { "--Box-gap": customValue } : {}),
     ...(wrap ? { flexWrap: wrap } : {}),
   } as React.CSSProperties;
 
   return (
-    <div
-      className={`Box Box--${gap} ${addlClassName ?? ""}`}
-      {...(gap === "custom" ? { gap: customValue } : {})}
-      style={customStyle}
-      {...props}
-    >
+    <div className={`Box Box--${gap} ${addlClassName ?? ""}`} style={customStyle} {...props}>
       {children}
     </div>
   );

--- a/src/components/Box/styles.scss
+++ b/src/components/Box/styles.scss
@@ -31,4 +31,8 @@
   &--xxl {
     gap: var(--sds-gap-xxl);
   }
+
+  &--custom {
+    gap: var(--Box-gap);
+  }
 }


### PR DESCRIPTION
### What

Fix the Box component's gap="custom" variant, which never applied a gap.

- `src/components/Box/index.tsx`: the custom value is now carried as a CSS custom property (`--Box-gap`) in the element's style object, the same way Box already carries direction, justify and align. The previous code spread `gap={customValue}` onto the `<div>` as an HTML attribute.
- `src/components/Box/styles.scss`: add the missing `.Box--custom { gap: var(--Box-gap) }` rule.

Pre-fix proof:
<img width="1592" height="277" alt="image" src="https://github.com/user-attachments/assets/9a516aa9-dbbf-4b81-a078-2cda6df0ef12" />

Post-fix:
<img width="1611" height="277" alt="image" src="https://github.com/user-attachments/assets/1c52029e-6b38-4ad5-8bd6-bd31cdde86d0" />

### Why

Box supports `gap="xs" | "sm" | "md" | "lg" | "xl" | "xxl"` (design tokens via modifier classes) plus an escape hatch: `gap="custom"` with a `customValue`. The escape hatch was broken in two ways:

1. `customValue` was rendered as a `gap="…"` attribute on the div. Browsers have no such attribute (only the CSS property gap means anything) so it did nothing, and React logged an unknown-prop warning.
2. The class it produced, `Box--custom`, had no rule in the stylesheet.

### Known limitations

- This PR is pure future-proofing. There is currently no consumer of gap="custom", so no rendered change anywhere.

### Checklist

- [x] Title follows `SDP-1234: Add new feature` or `Chore: Refactor package xyz` format. The Jira ticket code was included if available.
- [x] PR has a focused scope and doesn't mix features with refactoring
- [x] `CHANGELOG.md` is updated (if applicable)
- [ ] Preview deployment works as expected
- [ ] CONFIG/SECRETS changes are updated in helmcharts and deployments (if applicable)
- [ ] Ready for production
